### PR TITLE
스케쥴 목록 조회

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,13 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
     runtimeOnly 'com.h2database:h2'
+
+    // Querydsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/project/trainingdiary/config/AppConfig.java
+++ b/src/main/java/com/project/trainingdiary/config/AppConfig.java
@@ -1,5 +1,7 @@
 package com.project.trainingdiary.config;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -15,5 +17,13 @@ public class AppConfig {
   @Bean
   public PasswordEncoder passwordEncoder() {
     return new BCryptPasswordEncoder();
+  }
+
+  /**
+   * QueryDSL에서 사용하는 JPAQueryFactory를 Bean으로 등록합니다.
+   */
+  @Bean
+  public JPAQueryFactory jpaQueryFactory(EntityManager em) {
+    return new JPAQueryFactory(em);
   }
 }

--- a/src/main/java/com/project/trainingdiary/controller/ScheduleController.java
+++ b/src/main/java/com/project/trainingdiary/controller/ScheduleController.java
@@ -2,13 +2,18 @@ package com.project.trainingdiary.controller;
 
 import com.project.trainingdiary.dto.request.OpenScheduleRequestDto;
 import com.project.trainingdiary.dto.response.CommonResponse;
+import com.project.trainingdiary.dto.response.ScheduleResponseDto;
 import com.project.trainingdiary.model.SuccessMessage;
 import com.project.trainingdiary.service.ScheduleService;
 import jakarta.validation.Valid;
+import java.time.LocalDate;
+import java.util.List;
 import lombok.AllArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -24,5 +29,13 @@ public class ScheduleController {
   ) {
     scheduleService.createSchedule(dto);
     return CommonResponse.success(SuccessMessage.SCHEDULE_OPEN_SUCCESS);
+  }
+
+  @GetMapping("/")
+  public CommonResponse<?> getScheduleList(
+      @RequestParam LocalDate startDate,
+      @RequestParam LocalDate endDate
+  ) {
+    return CommonResponse.success(scheduleService.getScheduleList(startDate, endDate));
   }
 }

--- a/src/main/java/com/project/trainingdiary/controller/ScheduleController.java
+++ b/src/main/java/com/project/trainingdiary/controller/ScheduleController.java
@@ -2,12 +2,10 @@ package com.project.trainingdiary.controller;
 
 import com.project.trainingdiary.dto.request.OpenScheduleRequestDto;
 import com.project.trainingdiary.dto.response.CommonResponse;
-import com.project.trainingdiary.dto.response.ScheduleResponseDto;
 import com.project.trainingdiary.model.SuccessMessage;
 import com.project.trainingdiary.service.ScheduleService;
 import jakarta.validation.Valid;
 import java.time.LocalDate;
-import java.util.List;
 import lombok.AllArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -31,7 +29,7 @@ public class ScheduleController {
     return CommonResponse.success(SuccessMessage.SCHEDULE_OPEN_SUCCESS);
   }
 
-  @GetMapping("/")
+  @GetMapping
   public CommonResponse<?> getScheduleList(
       @RequestParam LocalDate startDate,
       @RequestParam LocalDate endDate

--- a/src/main/java/com/project/trainingdiary/dto/request/OpenScheduleRequestDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/request/OpenScheduleRequestDto.java
@@ -1,6 +1,7 @@
 package com.project.trainingdiary.dto.request;
 
 import com.project.trainingdiary.entity.ScheduleEntity;
+import com.project.trainingdiary.model.ScheduleDateTimes;
 import com.project.trainingdiary.model.ScheduleStatus;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;

--- a/src/main/java/com/project/trainingdiary/dto/response/ScheduleResponseDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/response/ScheduleResponseDto.java
@@ -1,0 +1,32 @@
+package com.project.trainingdiary.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.project.trainingdiary.entity.ScheduleEntity;
+import com.project.trainingdiary.model.ScheduleStatus;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class ScheduleResponseDto {
+
+  private Long id;
+
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
+  private LocalTime startTime;
+  private LocalDate startDate;
+  private ScheduleStatus status;
+
+  public static ScheduleResponseDto of(ScheduleEntity entity) {
+    return ScheduleResponseDto.builder()
+        .id(entity.getId())
+        .startDate(entity.getStartAt().toLocalDate())
+        .startTime(entity.getStartAt().toLocalTime())
+        .status(entity.getScheduleStatus())
+        .build();
+  }
+}

--- a/src/main/java/com/project/trainingdiary/dto/response/ScheduleResponseDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/response/ScheduleResponseDto.java
@@ -1,10 +1,8 @@
 package com.project.trainingdiary.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.project.trainingdiary.entity.ScheduleEntity;
-import com.project.trainingdiary.model.ScheduleStatus;
+import com.project.trainingdiary.model.ScheduleResponseDetail;
 import java.time.LocalDate;
-import java.time.LocalTime;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -14,19 +12,7 @@ import lombok.Setter;
 @Builder
 public class ScheduleResponseDto {
 
-  private Long id;
-
-  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
-  private LocalTime startTime;
   private LocalDate startDate;
-  private ScheduleStatus status;
-
-  public static ScheduleResponseDto of(ScheduleEntity entity) {
-    return ScheduleResponseDto.builder()
-        .id(entity.getId())
-        .startDate(entity.getStartAt().toLocalDate())
-        .startTime(entity.getStartAt().toLocalTime())
-        .status(entity.getScheduleStatus())
-        .build();
-  }
+  private boolean existReserved;
+  private List<ScheduleResponseDetail> details;
 }

--- a/src/main/java/com/project/trainingdiary/entity/ScheduleEntity.java
+++ b/src/main/java/com/project/trainingdiary/entity/ScheduleEntity.java
@@ -28,8 +28,10 @@ public class ScheduleEntity {
   @GeneratedValue(strategy = IDENTITY)
   private Long id;
 
+  @Column(nullable = false)
   private LocalDateTime startAt;
 
+  @Column(nullable = false)
   private LocalDateTime endAt;
 
   @Enumerated(value = STRING)

--- a/src/main/java/com/project/trainingdiary/exception/impl/ScheduleRangeTooLong.java
+++ b/src/main/java/com/project/trainingdiary/exception/impl/ScheduleRangeTooLong.java
@@ -1,0 +1,11 @@
+package com.project.trainingdiary.exception.impl;
+
+import com.project.trainingdiary.exception.GlobalException;
+import org.springframework.http.HttpStatus;
+
+public class ScheduleRangeTooLong extends GlobalException {
+
+  public ScheduleRangeTooLong() {
+    super(HttpStatus.BAD_REQUEST, "일정 간격이 너무 깁니다.");
+  }
+}

--- a/src/main/java/com/project/trainingdiary/model/ScheduleDateTimes.java
+++ b/src/main/java/com/project/trainingdiary/model/ScheduleDateTimes.java
@@ -1,4 +1,4 @@
-package com.project.trainingdiary.dto.request;
+package com.project.trainingdiary.model;
 
 import java.time.LocalDate;
 import java.time.LocalTime;

--- a/src/main/java/com/project/trainingdiary/model/ScheduleResponseDetail.java
+++ b/src/main/java/com/project/trainingdiary/model/ScheduleResponseDetail.java
@@ -1,0 +1,21 @@
+package com.project.trainingdiary.model;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class ScheduleResponseDetail {
+
+  private Long id;
+
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
+  private LocalTime startTime;
+  private String trainerName;
+  private String traineeName;
+  private ScheduleStatus status;
+}

--- a/src/main/java/com/project/trainingdiary/model/ScheduleStatus.java
+++ b/src/main/java/com/project/trainingdiary/model/ScheduleStatus.java
@@ -4,5 +4,5 @@ public enum ScheduleStatus {
 
   OPEN,
   RESERVE_APPLIED,
-  RESERVE_APPROVED
+  RESERVED
 }

--- a/src/main/java/com/project/trainingdiary/repository/ScheduleRepository.java
+++ b/src/main/java/com/project/trainingdiary/repository/ScheduleRepository.java
@@ -7,7 +7,8 @@ import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-public interface ScheduleRepository extends JpaRepository<ScheduleEntity, Long> {
+public interface ScheduleRepository extends JpaRepository<ScheduleEntity, Long>,
+    ScheduleRepositoryCustom {
 
   @Query("select s.startAt from schedule s where s.startAt >= ?1 AND s.startAt <= ?2")
   Set<LocalDateTime> findScheduleDatesByDates(LocalDateTime startAt1, LocalDateTime startAt2);

--- a/src/main/java/com/project/trainingdiary/repository/ScheduleRepository.java
+++ b/src/main/java/com/project/trainingdiary/repository/ScheduleRepository.java
@@ -2,6 +2,7 @@ package com.project.trainingdiary.repository;
 
 import com.project.trainingdiary.entity.ScheduleEntity;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -9,5 +10,8 @@ import org.springframework.data.jpa.repository.Query;
 public interface ScheduleRepository extends JpaRepository<ScheduleEntity, Long> {
 
   @Query("select s.startAt from schedule s where s.startAt >= ?1 AND s.startAt <= ?2")
-  Set<LocalDateTime> findByDates(LocalDateTime startAt1, LocalDateTime startAt2);
+  Set<LocalDateTime> findScheduleDatesByDates(LocalDateTime startAt1, LocalDateTime startAt2);
+
+  @Query("select s from schedule s where s.startAt >= ?1 AND s.startAt <= ?2")
+  List<ScheduleEntity> findByDates(LocalDateTime startAt1, LocalDateTime startAt2);
 }

--- a/src/main/java/com/project/trainingdiary/repository/ScheduleRepositoryCustom.java
+++ b/src/main/java/com/project/trainingdiary/repository/ScheduleRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.project.trainingdiary.repository;
+
+import com.project.trainingdiary.dto.response.ScheduleResponseDto;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface ScheduleRepositoryCustom {
+
+  List<ScheduleResponseDto> getScheduleList(LocalDateTime startDateTime, LocalDateTime endDateTime);
+}

--- a/src/main/java/com/project/trainingdiary/repository/ScheduleRepositoryImpl.java
+++ b/src/main/java/com/project/trainingdiary/repository/ScheduleRepositoryImpl.java
@@ -1,0 +1,84 @@
+package com.project.trainingdiary.repository;
+
+import static com.project.trainingdiary.entity.QScheduleEntity.scheduleEntity;
+import static com.querydsl.core.types.dsl.Expressions.dateTemplate;
+
+import com.project.trainingdiary.dto.response.ScheduleResponseDto;
+import com.project.trainingdiary.model.ScheduleResponseDetail;
+import com.project.trainingdiary.model.ScheduleStatus;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.ConstantImpl;
+import com.querydsl.core.types.dsl.DateExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class ScheduleRepositoryImpl implements ScheduleRepositoryCustom {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public List<ScheduleResponseDto> getScheduleList(LocalDateTime startDateTime,
+      LocalDateTime endDateTime) {
+    List<Tuple> results = queryFactory
+        .select(
+            scheduleEntity.id,
+            startDate(),
+            startTime(),
+            scheduleEntity.scheduleStatus
+        )
+        .from(scheduleEntity)
+        .where(scheduleEntity.startAt.between(startDateTime, endDateTime))
+        .fetch();
+
+    Map<String, List<Tuple>> groupedByDate = results.stream()
+        .collect(Collectors.groupingBy(tuple -> tuple.get(startDate())));
+
+    return groupedByDate.entrySet().stream()
+        .map(entry -> {
+          LocalDate date = LocalDate.parse(entry.getKey());
+          List<Tuple> tuples = entry.getValue();
+          List<ScheduleResponseDetail> details = tuples.stream()
+              .map(tuple -> ScheduleResponseDetail.builder()
+                  .id(tuple.get(scheduleEntity.id))
+                  .startTime(LocalTime.parse(tuple.get(startTime())))
+                  .status(tuple.get(scheduleEntity.scheduleStatus))
+                  .build()
+              )
+              .collect(Collectors.toList());
+          boolean existReserved = details.stream()
+              .anyMatch(detail -> detail.getStatus() == ScheduleStatus.RESERVED);
+          return ScheduleResponseDto.builder()
+              .startDate(date)
+              .existReserved(existReserved)
+              .details(details)
+              .build();
+        })
+        .collect(Collectors.toList());
+  }
+
+  // date_format 함수는 MariaDB에서 동작함(H2에서 동작하지 않는 게 확인됨)
+  private DateExpression<String> startDate() {
+    return dateTemplate(
+        String.class,
+        "date_format({0}, {1})",
+        scheduleEntity.startAt,
+        ConstantImpl.create("%Y-%m-%d")
+    ).as("startDate");
+  }
+
+  private DateExpression<String> startTime() {
+    return dateTemplate(
+        String.class,
+        "date_format({0}, {1})",
+        scheduleEntity.startAt,
+        ConstantImpl.create("%H:%i") // H는 24시간 기준 2자리. i는 분 2자리
+    ).as("startTime");
+  }
+}

--- a/src/main/java/com/project/trainingdiary/service/ScheduleService.java
+++ b/src/main/java/com/project/trainingdiary/service/ScheduleService.java
@@ -1,11 +1,16 @@
 package com.project.trainingdiary.service;
 
 import com.project.trainingdiary.dto.request.OpenScheduleRequestDto;
+import com.project.trainingdiary.dto.response.ScheduleResponseDto;
 import com.project.trainingdiary.entity.ScheduleEntity;
 import com.project.trainingdiary.exception.impl.ScheduleAlreadyExistException;
 import com.project.trainingdiary.exception.impl.ScheduleInvalidException;
+import com.project.trainingdiary.exception.impl.ScheduleRangeTooLong;
 import com.project.trainingdiary.repository.ScheduleRepository;
+import java.time.Duration;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
@@ -18,6 +23,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class ScheduleService {
 
+  private static final int MAX_QUERY_DAYS = 180;
+
   private final ScheduleRepository scheduleRepository;
 
   @Transactional
@@ -26,7 +33,7 @@ public class ScheduleService {
 
     List<ScheduleEntity> scheduleEntities = dto.toEntities();
 
-    Set<LocalDateTime> existings = scheduleRepository.findByDates(
+    Set<LocalDateTime> existings = scheduleRepository.findScheduleDatesByDates(
         getEarliest(scheduleEntities),
         getLatest(scheduleEntities)
     );
@@ -40,9 +47,20 @@ public class ScheduleService {
     scheduleRepository.saveAll(scheduleEntities);
   }
 
-  public List<ScheduleEntity> getScheduleList() {
-    //TODO: 기간으로 받아서 목록 조회하기. 현재는 테스트 확인용
-    return scheduleRepository.findAll();
+  public List<ScheduleResponseDto> getScheduleList(LocalDate startDate, LocalDate endDate) {
+    //TODO: 트레이니와 트레이너의 구분에 따라 다른 내용을 보여줘야 함
+
+    LocalDateTime startDateTime = LocalDateTime.of(startDate, LocalTime.of(0, 0));
+    LocalDateTime endDateTime = LocalDateTime.of(endDate, LocalTime.of(23, 59));
+
+    if (Duration.between(startDateTime, endDateTime).toDays() > MAX_QUERY_DAYS) {
+      throw new ScheduleRangeTooLong();
+    }
+
+    return scheduleRepository
+        .findByDates(startDateTime, endDateTime).stream()
+        .map(ScheduleResponseDto::of)
+        .toList();
   }
 
   private static LocalDateTime getLatest(List<ScheduleEntity> scheduleEntities) {

--- a/src/main/java/com/project/trainingdiary/service/ScheduleService.java
+++ b/src/main/java/com/project/trainingdiary/service/ScheduleService.java
@@ -57,10 +57,7 @@ public class ScheduleService {
       throw new ScheduleRangeTooLong();
     }
 
-    return scheduleRepository
-        .findByDates(startDateTime, endDateTime).stream()
-        .map(ScheduleResponseDto::of)
-        .toList();
+    return scheduleRepository.getScheduleList(startDateTime, endDateTime);
   }
 
   private static LocalDateTime getLatest(List<ScheduleEntity> scheduleEntities) {

--- a/src/test/java/com/project/trainingdiary/service/ScheduleServiceTest.java
+++ b/src/test/java/com/project/trainingdiary/service/ScheduleServiceTest.java
@@ -1,4 +1,4 @@
-package com.project.trainingdiary.service.impl;
+package com.project.trainingdiary.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -12,7 +12,6 @@ import com.project.trainingdiary.model.ScheduleDateTimes;
 import com.project.trainingdiary.model.ScheduleResponseDetail;
 import com.project.trainingdiary.model.ScheduleStatus;
 import com.project.trainingdiary.repository.ScheduleRepository;
-import com.project.trainingdiary.service.ScheduleService;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -28,7 +27,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @DisplayName("일정 서비스")
 @ExtendWith(MockitoExtension.class)
-class ScheduleServiceImplTest {
+class ScheduleServiceTest {
 
   @Mock
   private ScheduleRepository scheduleRepository;


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요 -->
**AS-IS**
- 스케쥴 목록 조회 필요

**TO-BE**
- 스케쥴 목록 조회 추가
  - 스케쥴을 날짜로 묶고, 날짜별 각 스케쥴의 상태를 보여줌
  - 날짜마다 당일에 예약된 스케쥴이 있는지 없는지 표시

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
  - 일정 목록 조회 - 성공
  - 일정 목록 조회 - 실패(조회 범위가 너무 큰 경우). 조회 범위 제한은 180일을 가정해 놓았음. 현재 서비스에서는 1달 단위로 화면을 보여주고 있음. 앞뒤 달을 미리 가져오도록 한다고 해도 포괄할 수 있도록 범위를 잡아놓음.
- [x] API 테스트

api/schedules GET 호출 결과
```
{
  "data": [
    {
      "startDate": "2024-07-11",
      "existReserved": false,
      "details": [
        {
          "id": 19,
          "startTime": "09:00",
          "trainerName": null,
          "traineeName": null,
          "status": "OPEN"
        },
        {
          "id": 20,
          "startTime": "10:00",
          "trainerName": null,
          "traineeName": null,
          "status": "OPEN"
        },
        {
          "id": 21,
          "startTime": "11:00",
          "trainerName": null,
          "traineeName": null,
          "status": "OPEN"
        }
      ]
    },
    {
      "startDate": "2024-07-10",
      "existReserved": false,
      "details": [
        {
          "id": 17,
          "startTime": "17:00",
          "trainerName": null,
          "traineeName": null,
          "status": "OPEN"
        },
        {
          "id": 18,
          "startTime": "18:00",
          "trainerName": null,
          "traineeName": null,
          "status": "OPEN"
        }
      ]
    }
  ],
  "message": "성공",
  "statusCode": 200
}
```

trainer, trainee는 추후 연결 예정
