### PR TITLE
스케쥴 닫기 기능 추가

### DIFF
--- a/src/main/java/com/project/trainingdiary/controller/ScheduleController.java
+++ b/src/main/java/com/project/trainingdiary/controller/ScheduleController.java
@@ -1,5 +1,6 @@
 package com.project.trainingdiary.controller;
 
+import com.project.trainingdiary.dto.request.CloseScheduleRequestDto;
 import com.project.trainingdiary.dto.request.OpenScheduleRequestDto;
 import com.project.trainingdiary.dto.response.CommonResponse;
 import com.project.trainingdiary.model.SuccessMessage;
@@ -35,5 +36,13 @@ public class ScheduleController {
       @RequestParam LocalDate endDate
   ) {
     return CommonResponse.success(scheduleService.getScheduleList(startDate, endDate));
+  }
+
+  @PostMapping("/trainers/close")
+  public CommonResponse<?> closeSchedules(
+      @RequestBody @Valid CloseScheduleRequestDto dto
+  ) {
+    scheduleService.closeSchedules(dto.scheduleIds);
+    return CommonResponse.success();
   }
 }

--- a/src/main/java/com/project/trainingdiary/dto/request/CloseScheduleRequestDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/request/CloseScheduleRequestDto.java
@@ -1,0 +1,20 @@
+package com.project.trainingdiary.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CloseScheduleRequestDto {
+
+  @NotNull(message = "scheduleIds를 입력해주세요")
+  public List<Long> scheduleIds;
+}

--- a/src/main/java/com/project/trainingdiary/exception/impl/ScheduleNotFoundException.java
+++ b/src/main/java/com/project/trainingdiary/exception/impl/ScheduleNotFoundException.java
@@ -1,0 +1,11 @@
+package com.project.trainingdiary.exception.impl;
+
+import com.project.trainingdiary.exception.GlobalException;
+import org.springframework.http.HttpStatus;
+
+public class ScheduleNotFoundException extends GlobalException {
+
+  public ScheduleNotFoundException() {
+    super(HttpStatus.NOT_FOUND, "스케쥴이 없습니다.");
+  }
+}

--- a/src/main/java/com/project/trainingdiary/exception/impl/ScheduleStatusNotOpenException.java
+++ b/src/main/java/com/project/trainingdiary/exception/impl/ScheduleStatusNotOpenException.java
@@ -1,0 +1,11 @@
+package com.project.trainingdiary.exception.impl;
+
+import com.project.trainingdiary.exception.GlobalException;
+import org.springframework.http.HttpStatus;
+
+public class ScheduleStatusNotOpenException extends GlobalException {
+
+  public ScheduleStatusNotOpenException() {
+    super(HttpStatus.CONFLICT, "스케쥴이 OPEN 상태가 아닙니다.");
+  }
+}

--- a/src/main/java/com/project/trainingdiary/service/ScheduleService.java
+++ b/src/main/java/com/project/trainingdiary/service/ScheduleService.java
@@ -5,7 +5,10 @@ import com.project.trainingdiary.dto.response.ScheduleResponseDto;
 import com.project.trainingdiary.entity.ScheduleEntity;
 import com.project.trainingdiary.exception.impl.ScheduleAlreadyExistException;
 import com.project.trainingdiary.exception.impl.ScheduleInvalidException;
+import com.project.trainingdiary.exception.impl.ScheduleNotFoundException;
 import com.project.trainingdiary.exception.impl.ScheduleRangeTooLong;
+import com.project.trainingdiary.exception.impl.ScheduleStatusNotOpenException;
+import com.project.trainingdiary.model.ScheduleStatus;
 import com.project.trainingdiary.repository.ScheduleRepository;
 import java.time.Duration;
 import java.time.LocalDate;
@@ -58,6 +61,26 @@ public class ScheduleService {
     }
 
     return scheduleRepository.getScheduleList(startDateTime, endDateTime);
+  }
+
+  @Transactional
+  public void closeSchedules(List<Long> scheduleIds) {
+    // TODO: trainee는 일정을 닫을 수 없음
+
+    List<ScheduleEntity> schedules = scheduleRepository.findAllById(scheduleIds);
+
+    if (scheduleIds.size() != schedules.size()) {
+      throw new ScheduleNotFoundException();
+    }
+
+    long notOpenSchedule = schedules.stream()
+        .filter(s -> !s.getScheduleStatus().equals(ScheduleStatus.OPEN))
+        .count();
+    if (notOpenSchedule > 0) {
+      throw new ScheduleStatusNotOpenException();
+    }
+
+    scheduleRepository.deleteAll(schedules);
   }
 
   private static LocalDateTime getLatest(List<ScheduleEntity> scheduleEntities) {


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요 -->
**AS-IS**
- 스케쥴 닫기 기능 필요

**TO-BE**
- 스케쥴 닫기 기능 추가

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
  - 일정 닫기 - 성공
  - 일정 닫기 - 실패(스케쥴 아이디 목록 중에 없는 스케쥴이 있음)
  - 일정 닫기 - 실패(스케쥴이 OPEN 상태가 아님) - 스케쥴이 OPEN 상태가 아닌 것은 닫을 수 없음
- [x] API 테스트

api/schedules/trainers/close POST 
```
{
  "scheduleIds": [18]
}
```
취소하려는 schedule의 id 목록을 넘겨서 실행함