### PR TITLE
PT 계약 횟수 수정

### DIFF
--- a/src/main/java/com/project/trainingdiary/controller/PtContractController.java
+++ b/src/main/java/com/project/trainingdiary/controller/PtContractController.java
@@ -1,5 +1,6 @@
 package com.project.trainingdiary.controller;
 
+import com.project.trainingdiary.dto.request.AddPtContractSessionRequestDto;
 import com.project.trainingdiary.dto.request.CreatePtContractRequestDto;
 import com.project.trainingdiary.dto.response.CommonResponse;
 import com.project.trainingdiary.dto.response.PtContractResponseDto;
@@ -44,5 +45,13 @@ public class PtContractController {
   ) {
     PtContractResponseDto ptContract = ptContractService.getPtContract(id);
     return CommonResponse.success(ptContract);
+  }
+
+  @PostMapping("/add-session")
+  public CommonResponse<?> addPtContractSession(
+      @RequestBody @Valid AddPtContractSessionRequestDto dto
+  ) {
+    ptContractService.addPtContractSession(dto);
+    return CommonResponse.success();
   }
 }

--- a/src/main/java/com/project/trainingdiary/dto/request/AddPtContractSessionRequestDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/request/AddPtContractSessionRequestDto.java
@@ -1,0 +1,16 @@
+package com.project.trainingdiary.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AddPtContractSessionRequestDto {
+
+  @NotNull(message = "트레이니 id를 입력해주세요")
+  private Long traineeId;
+
+  @NotNull(message = "추가횟수를 입력해주세요")
+  private Integer addition;
+}

--- a/src/main/java/com/project/trainingdiary/dto/response/PtContractResponseDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/response/PtContractResponseDto.java
@@ -11,8 +11,9 @@ import lombok.Setter;
 public class PtContractResponseDto {
 
   private Long id;
-  private LocalDateTime sessionUpdatedAt;
+  private LocalDateTime totalSessionUpdatedAt;
   private int totalSession;
+  private int usedSession;
   private Long trainerId;
   private Long traineeId;
   private LocalDateTime createdAt;

--- a/src/main/java/com/project/trainingdiary/entity/PtContractEntity.java
+++ b/src/main/java/com/project/trainingdiary/entity/PtContractEntity.java
@@ -30,7 +30,11 @@ public class PtContractEntity extends BaseEntity {
 
   private int totalSession;
 
-  private LocalDateTime sessionUpdatedAt;
+  private int usedSession;
+
+  private LocalDateTime totalSessionUpdatedAt;
+
+  private boolean isTerminated;
 
   @ManyToOne(fetch = LAZY)
   @JoinColumn(name = "trainer_id")
@@ -40,11 +44,16 @@ public class PtContractEntity extends BaseEntity {
   @JoinColumn(name = "trainee_id")
   private TraineeEntity trainee;
 
+  public void addSession(int addition) {
+    this.totalSession += addition;
+    this.totalSessionUpdatedAt = LocalDateTime.now();
+  }
+
   public static PtContractEntity of(TrainerEntity trainer, TraineeEntity trainee,
       int sessionCount) {
     return PtContractEntity.builder()
         .totalSession(sessionCount)
-        .sessionUpdatedAt(LocalDateTime.now())
+        .totalSessionUpdatedAt(LocalDateTime.now())
         .trainer(trainer)
         .trainee(trainee)
         .build();
@@ -55,9 +64,10 @@ public class PtContractEntity extends BaseEntity {
         .id(id)
         .trainerId(trainer.getId())
         .traineeId(trainee.getId())
+        .usedSession(usedSession)
         .totalSession(totalSession)
         .createdAt(getCreatedAt())
-        .sessionUpdatedAt(sessionUpdatedAt)
+        .totalSessionUpdatedAt(totalSessionUpdatedAt)
         .build();
   }
 }

--- a/src/main/java/com/project/trainingdiary/repository/PtContractRepository.java
+++ b/src/main/java/com/project/trainingdiary/repository/PtContractRepository.java
@@ -19,10 +19,6 @@ public interface PtContractRepository extends JpaRepository<PtContractEntity, Lo
       + "and not(p.isTerminated)")
   boolean existsByTrainerIdAndTraineeId(long trainerId, long traineeId);
 
-  Page<PtContractEntity> findByTrainee_Email(String email, Pageable pageable);
-
-  Page<PtContractEntity> findByTrainer_Email(String email, Pageable pageable);
-
   @Query("select p "
       + "from pt_contract p "
       + "where p.trainer.id = ?1 "

--- a/src/main/java/com/project/trainingdiary/repository/PtContractRepository.java
+++ b/src/main/java/com/project/trainingdiary/repository/PtContractRepository.java
@@ -1,19 +1,46 @@
 package com.project.trainingdiary.repository;
 
 import com.project.trainingdiary.entity.PtContractEntity;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface PtContractRepository extends JpaRepository<PtContractEntity, Long> {
 
+  @Query("select case when count(p) > 0 "
+      + "then true "
+      + "else false "
+      + "end "
+      + "from pt_contract p "
+      + "where p.trainer.id = ?1 "
+      + "and p.trainee.id = ?2 "
+      + "and not(p.isTerminated)")
   boolean existsByTrainerIdAndTraineeId(long trainerId, long traineeId);
-
 
   Page<PtContractEntity> findByTrainee_Email(String email, Pageable pageable);
 
   Page<PtContractEntity> findByTrainer_Email(String email, Pageable pageable);
 
+  @Query("select p "
+      + "from pt_contract p "
+      + "where p.trainer.id = ?1 "
+      + "and p.trainee.id = ?2 "
+      + "and p.isTerminated = false")
   Optional<PtContractEntity> findByTrainerIdAndTraineeId(long trainerId, long traineeId);
+
+  @Query("select p "
+      + "from pt_contract p "
+      + "join p.trainer t "
+      + "where t.email = ?1 "
+      + "and p.isTerminated = false")
+  Page<PtContractEntity> findByTraineeEmail(String email, Pageable pageable);
+
+  @Query("select p "
+      + "from pt_contract p "
+      + "join p.trainer t "
+      + "where t.email = ?1 "
+      + "and p.isTerminated = false")
+  Page<PtContractEntity> findByTrainerEmail(String email, Pageable pageable);
 }

--- a/src/main/java/com/project/trainingdiary/security/SecurityConfig.java
+++ b/src/main/java/com/project/trainingdiary/security/SecurityConfig.java
@@ -31,7 +31,7 @@ public class SecurityConfig {
             .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html",
                 "/swagger-resources/**", "/webjars/**", "/h2-console/**", "api/users/**")
             .permitAll() // Swagger UI
-            .requestMatchers("/api/pt-contracts").authenticated()
+            .requestMatchers("/api/pt-contracts/**").authenticated()
             .anyRequest().authenticated())
         .exceptionHandling(exception -> exception
             .authenticationEntryPoint(new FailedAuthenticationEntryPoint()))

--- a/src/main/java/com/project/trainingdiary/service/PtContractService.java
+++ b/src/main/java/com/project/trainingdiary/service/PtContractService.java
@@ -1,5 +1,6 @@
 package com.project.trainingdiary.service;
 
+import com.project.trainingdiary.dto.request.AddPtContractSessionRequestDto;
 import com.project.trainingdiary.dto.request.CreatePtContractRequestDto;
 import com.project.trainingdiary.dto.response.PtContractResponseDto;
 import com.project.trainingdiary.entity.PtContractEntity;
@@ -45,10 +46,10 @@ public class PtContractService {
   public Page<PtContractResponseDto> getPtContractList(Pageable pageable) {
     //TODO: 연관된 트레이너, 트레이니 이름 추가. 이름순 정렬
     if (getMyRole().equals(UserRoleType.TRAINEE)) {
-      return ptContractRepository.findByTrainee_Email(getEmail(), pageable)
+      return ptContractRepository.findByTraineeEmail(getEmail(), pageable)
           .map(PtContractEntity::toResponseDto);
     } else {
-      return ptContractRepository.findByTrainer_Email(getEmail(), pageable)
+      return ptContractRepository.findByTrainerEmail(getEmail(), pageable)
           .map(PtContractEntity::toResponseDto);
     }
   }
@@ -69,6 +70,24 @@ public class PtContractService {
 
     return ptContract.toResponseDto();
   }
+
+  /**
+   * PT 계약 횟수를 업데이트 함
+   */
+  @Transactional
+  public void addPtContractSession(AddPtContractSessionRequestDto dto) {
+    TrainerEntity trainer = getTrainer();
+
+    // 1개의 계약만 있다는 것을 가정함
+    PtContractEntity ptContract = ptContractRepository
+        .findByTrainerIdAndTraineeId(trainer.getId(), dto.getTraineeId())
+        .orElseThrow(PtContractNotExistException::new);
+
+    ptContract.addSession(dto.getAddition());
+    ptContractRepository.save(ptContract);
+  }
+
+  //TODO: usedSession 업데이트를 해야함 - 예약 시간이 지나는 순간에 하면 좋을 듯
 
   private TrainerEntity getTrainer() {
     Authentication auth = SecurityContextHolder.getContext().getAuthentication();

--- a/src/main/java/com/project/trainingdiary/service/PtContractService.java
+++ b/src/main/java/com/project/trainingdiary/service/PtContractService.java
@@ -30,6 +30,9 @@ public class PtContractService {
   private final TrainerRepository trainerRepository;
   private final TraineeRepository traineeRepository;
 
+  /**
+   * PT 계약 생성
+   */
   @Transactional
   public void createPtContract(CreatePtContractRequestDto dto) {
     TrainerEntity trainer = getTrainer(); // 이 메서드를 호출한 사람은 트레이너임
@@ -43,6 +46,9 @@ public class PtContractService {
     ptContractRepository.save(ptContract);
   }
 
+  /**
+   * PT 계약을 목록으로 조회
+   */
   public Page<PtContractResponseDto> getPtContractList(Pageable pageable) {
     //TODO: 연관된 트레이너, 트레이니 이름 추가. 이름순 정렬
     if (getMyRole().equals(UserRoleType.TRAINEE)) {
@@ -54,6 +60,9 @@ public class PtContractService {
     }
   }
 
+  /**
+   * PT 계약을 id로 조회
+   */
   public PtContractResponseDto getPtContract(long id) {
     PtContractEntity ptContract = ptContractRepository.findById(id)
         .orElseThrow(PtContractNotExistException::new);

--- a/src/test/java/com/project/trainingdiary/service/PtContractServiceTest.java
+++ b/src/test/java/com/project/trainingdiary/service/PtContractServiceTest.java
@@ -214,7 +214,7 @@ class PtContractServiceTest {
     Pageable pageRequest = PageRequest.of(0, 20);
 
     //when
-    when(ptContractRepository.findByTrainer_Email("trainer@example.com", pageRequest))
+    when(ptContractRepository.findByTrainerEmail("trainer@example.com", pageRequest))
         .thenReturn(new PageImpl<>(list, pageRequest, 1));
 
     //then
@@ -251,7 +251,7 @@ class PtContractServiceTest {
     Pageable pageRequest = PageRequest.of(0, 20);
 
     //when
-    when(ptContractRepository.findByTrainee_Email("trainee@example.com", pageRequest))
+    when(ptContractRepository.findByTraineeEmail("trainee@example.com", pageRequest))
         .thenReturn(new PageImpl<>(list, pageRequest, 1));
 
     //then

--- a/src/test/java/com/project/trainingdiary/service/PtContractServiceTest.java
+++ b/src/test/java/com/project/trainingdiary/service/PtContractServiceTest.java
@@ -175,7 +175,7 @@ class PtContractServiceTest {
                 .trainee(trainee)
                 .trainer(trainer)
                 .totalSession(0)
-                .sessionUpdatedAt(LocalDateTime.now())
+                .totalSessionUpdatedAt(LocalDateTime.now())
                 .build()
         ));
 
@@ -208,7 +208,7 @@ class PtContractServiceTest {
             .trainee(trainee)
             .trainer(trainer)
             .totalSession(0)
-            .sessionUpdatedAt(LocalDateTime.now())
+            .totalSessionUpdatedAt(LocalDateTime.now())
             .build()
     );
     Pageable pageRequest = PageRequest.of(0, 20);
@@ -245,7 +245,7 @@ class PtContractServiceTest {
             .trainee(trainee)
             .trainer(trainer)
             .totalSession(0)
-            .sessionUpdatedAt(LocalDateTime.now())
+            .totalSessionUpdatedAt(LocalDateTime.now())
             .build()
     );
     Pageable pageRequest = PageRequest.of(0, 20);


### PR DESCRIPTION
### 변경사항

<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요 -->
**AS-IS**
- PT 계약 횟수 수정 기능 필요

**TO-BE**
- PT 계약 횟수 수정 기능 추가

### 테스트

<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 

- [x] 테스트 코드
  - PT 계약 횟수 증가 - 성공
  - PT 계약 횟수 증가 - 실패(둘 사이 계약이 없는 경우)
- [x] API 테스트

POST api/pt-contracts/add-session 호출
```
{
  "traineeId": 1,
  "addition": 10
}
```

### 업데이트 성격이지만 PUT이 아닌 POST로 작성한 이유
PUT은 idempotent여서, 한 번 호출하든, 여러 번 호출하든 같은 효과를 내도록 만들어져야 한다. 하지만, 위 api는 호출될 때마다 계속 추가되기 때문에 PUT이 맞지 않다.
https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PUT
GET, PUT은 idempotent여서 네트워크 레벨에서 호출 실패라고 판단되는 부분에 대해 내부적으로 알아서 재시도해보는 로직이 실행될 수 있다고 알고 있다.