### PR TITLE
공통 Response 객체 생성 - CustomResponse

### DIFF
--- a/src/main/java/com/project/trainingdiary/controller/SampleController.java
+++ b/src/main/java/com/project/trainingdiary/controller/SampleController.java
@@ -1,8 +1,10 @@
 package com.project.trainingdiary.controller;
 
 import com.project.trainingdiary.dto.response.CommonResponse;
+import com.project.trainingdiary.dto.response.CustomResponse;
 import com.project.trainingdiary.dto.response.ExampleResponseDto;
 import com.project.trainingdiary.exception.GlobalException;
+import com.project.trainingdiary.model.SuccessMessage;
 import com.project.trainingdiary.model.UserPrincipal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -12,8 +14,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-// CommonResponse를 보여주기 위한 Sample 응답입니다.
-// dto를 넣어서 CommonResponse를 만들면,
+// CustomResponse를 보여주기 위한 Sample 응답입니다.
+// dto를 넣어서 CustomResponse를 만들면,
 // 아래와 같이 statusCode와 message를 추가하고, data에 dto를 넣어 응답을 생성합니다.
 // {
 //  "data": {
@@ -23,8 +25,6 @@ import org.springframework.web.bind.annotation.RestController;
 //  "message": "성공",
 //  "statusCode": 200
 // }
-//
-// 이 SampleController 파일은 1주일 후(2024.7.9.) 삭제하겠습니다.
 
 @RestController
 public class SampleController {
@@ -32,62 +32,41 @@ public class SampleController {
   private static final Logger log = LoggerFactory.getLogger(SampleController.class);
 
   @GetMapping("/sample/success")
-  public CommonResponse<?> sampleSuccess() {
+  public CustomResponse<ExampleResponseDto> sampleSuccess() {
     ExampleResponseDto dto = new ExampleResponseDto("sample", 30);
-    return new CommonResponse<>(dto, HttpStatus.OK, "성공입니다.");
+    return CustomResponse.success(dto);
   }
 
   @GetMapping("/sample/success/simple")
-  public CommonResponse<?> sampleSuccessSimple() {
+  public CustomResponse<ExampleResponseDto> sampleSuccessSimple() {
     ExampleResponseDto dto = new ExampleResponseDto("sample", 30);
-    return CommonResponse.success(dto);
-  }
-
-  @GetMapping("/sample/created")
-  public CommonResponse<?> sampleCreated() {
-    ExampleResponseDto dto = new ExampleResponseDto("sample", 30);
-    return CommonResponse.created(dto);
-  }
-
-  @GetMapping("/sample/client-fail")
-  public CommonResponse<?> sampleClientFail() {
-    return new CommonResponse<>(HttpStatus.NOT_FOUND, "리소스가 없습니다.");
-  }
-
-  @GetMapping("/sample/client-fail/simple")
-  public CommonResponse<?> sampleClientFailSimple() {
-    return CommonResponse.clientFail();
-  }
-
-  @GetMapping("/sample/server-fail")
-  public CommonResponse<?> sampleServerFail() {
-    return CommonResponse.serverFail("내부 서버 에러입니다.");
+    return CustomResponse.success(dto, SuccessMessage.SIGN_UP_SUCCESS);
   }
 
   @GetMapping("/sample/exception")
-  public CommonResponse<?> sampleException() {
+  public CustomResponse<Void> sampleException() {
     throw new GlobalException(HttpStatus.NOT_FOUND, "리소스가 없습니다.");
   }
 
   @GetMapping("api/test/protected")
-  public CommonResponse<?> protectedEndpoint(@AuthenticationPrincipal UserPrincipal userPrincipal) {
+  public CustomResponse<String> protectedEndpoint(@AuthenticationPrincipal UserPrincipal userPrincipal) {
     log.info("User: {}", userPrincipal.getUsername());
-    return CommonResponse.success("인증 권한 있습니다");
+    return CustomResponse.success("인증 권한 있습니다");
   }
 
   @PreAuthorize("hasRole('TRAINER')")
   @GetMapping("api/test/trainer")
-  public CommonResponse<?> preAuthorizeTrainer(
+  public CustomResponse<String> preAuthorizeTrainer(
       @AuthenticationPrincipal UserPrincipal userPrincipal) {
     log.info("User: {}", userPrincipal.getAuthorities());
-    return CommonResponse.success("인증 권한 있습니다");
+    return CustomResponse.success("인증 권한 있습니다");
   }
 
   @PreAuthorize("hasRole('TRAINEE')")
   @GetMapping("api/test/trainee")
-  public CommonResponse<?> preAuthorizeTrainee(
+  public CustomResponse<String> preAuthorizeTrainee(
       @AuthenticationPrincipal UserPrincipal userPrincipal) {
     log.info("User: {}", userPrincipal.getAuthorities());
-    return CommonResponse.success("인증 권한 있습니다");
+    return CustomResponse.success("인증 권한 있습니다");
   }
 }

--- a/src/main/java/com/project/trainingdiary/dto/response/CommonResponse.java
+++ b/src/main/java/com/project/trainingdiary/dto/response/CommonResponse.java
@@ -7,7 +7,9 @@ import org.springframework.http.ResponseEntity;
 
 /**
  * Response 공통화
+ * @deprecated 이 클래스 대신 CustomResponse를 사용하세요.
  */
+@Deprecated
 public class CommonResponse<T> extends ResponseEntity<Map<String, Object>> {
 
   private static final String STATUS_CODE = "statusCode";

--- a/src/main/java/com/project/trainingdiary/dto/response/CustomResponse.java
+++ b/src/main/java/com/project/trainingdiary/dto/response/CustomResponse.java
@@ -1,0 +1,64 @@
+package com.project.trainingdiary.dto.response;
+
+import com.project.trainingdiary.exception.GlobalException;
+import com.project.trainingdiary.model.SuccessMessage;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * Response 공통화. 성공의 경우 SuccessMessage를 정의 후 사용해주세요. 실패의 경우 GlobalException을 활용해주세요.
+ */
+public class CustomResponse<T> extends ResponseEntity<Map<String, Object>> {
+
+  private static final String STATUS_CODE = "statusCode";
+  private static final String ERROR_CODE = "errorCode";
+  private static final String MESSAGE = "message";
+  private static final String DATA = "data";
+  private static final int MIN_ERROR_CODE = 400;
+
+  public CustomResponse(T body, HttpStatus status, String message) {
+    super(createResponseMap(body, status, message), status);
+  }
+
+  public CustomResponse(HttpStatus status, String message) {
+    super(createResponseMap(new HashMap<>(), status, message), status);
+  }
+
+  private static <T> Map<String, Object> createResponseMap(
+      T body, HttpStatus status, String message
+  ) {
+    HashMap<String, Object> response = new HashMap<>();
+
+    if (status.value() < MIN_ERROR_CODE) {
+      response.put(STATUS_CODE, status.value());
+      response.put(DATA, body);
+    } else {
+      response.put(ERROR_CODE, status.value());
+    }
+    response.put(MESSAGE, message);
+
+    return response;
+  }
+
+  public static <T> CustomResponse<T> success() {
+    return new CustomResponse<>(HttpStatus.OK, "성공");
+  }
+
+  public static <T> CustomResponse<T> success(T body) {
+    return new CustomResponse<>(body, HttpStatus.OK, "성공");
+  }
+
+  public static <T> CustomResponse<T> success(SuccessMessage message) {
+    return new CustomResponse<>(message.getStatus(), message.getMessage());
+  }
+
+  public static <T> CustomResponse<T> success(T body, SuccessMessage message) {
+    return new CustomResponse<>(body, message.getStatus(), message.getMessage());
+  }
+
+  public static CustomResponse<Void> fail(GlobalException exception) {
+    return new CustomResponse<>(exception.getHttpStatus(), exception.getMessage());
+  }
+}


### PR DESCRIPTION
### 변경사항

<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요 -->
**AS-IS**
- CommonResponse를 사용해 응답을 공통화 함
- CommonResponse에 ? 를 사용해 응답 데이터 타입을 대신함. 이걸 해결하려 함

**TO-BE**
- CustomResponse를 사용할 수 있도록 새롭게 생성
- CustomResponse<XxResponseDto>처럼 타입을 명시해 쓰도록 함
- SuccessMessage의 상태코드를 사용해서 success, created로 분리되었던 것을 success만 사용하도록 함

### 샘플

```java
  @GetMapping("/sample/success/simple")
  public CustomResponse<ExampleResponseDto> sampleSuccessSimple() {
    ExampleResponseDto dto = new ExampleResponseDto("sample", 30);
    return CustomResponse.success(dto, SuccessMessage.SIGN_UP_SUCCESS);
  }
```
응답 데이터 타입(ExampleResponseDto)을 명시하고, SuccessMessage를 정의한 후 사용

Resolves #30 