### PR TITLE
운동 일지 이미지 업로드

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,13 @@ dependencies {
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    // AWS S3
+    implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.1.1")
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3'
+
+    // image resize
+    implementation 'org.imgscalr:imgscalr-lib:4.2'
+
     // Querydsl
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"

--- a/src/main/java/com/project/trainingdiary/config/AwsS3Config.java
+++ b/src/main/java/com/project/trainingdiary/config/AwsS3Config.java
@@ -1,0 +1,52 @@
+package com.project.trainingdiary.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.regions.providers.AwsRegionProvider;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class AwsS3Config {
+
+  @Value("${spring.cloud.aws.credentials.access-key}")
+  private String accessKey;
+
+  @Value("${spring.cloud.aws.credentials.secret-key}")
+  private String secretKey;
+
+  @Value("${spring.cloud.aws.region.static}")
+  private String region;
+
+  @Bean
+  public AwsCredentialsProvider customAwsCredentialsProvider() {
+    return () -> new AwsCredentials() {
+      @Override
+      public String accessKeyId() {
+        return accessKey;
+      }
+
+      @Override
+      public String secretAccessKey() {
+        return secretKey;
+      }
+    };
+  }
+
+  @Bean
+  public S3Client s3Client() {
+    return S3Client.builder()
+        .credentialsProvider(customAwsCredentialsProvider())
+        .region(customAwsRegionProvider().getRegion())
+        .build();
+  }
+
+  @Bean
+  public AwsRegionProvider customAwsRegionProvider() {
+    return () -> Region.of(region);
+  }
+
+}

--- a/src/main/java/com/project/trainingdiary/controller/WorkoutSessionController.java
+++ b/src/main/java/com/project/trainingdiary/controller/WorkoutSessionController.java
@@ -3,6 +3,7 @@ package com.project.trainingdiary.controller;
 import com.project.trainingdiary.dto.request.WorkoutImageRequestDto;
 import com.project.trainingdiary.dto.request.WorkoutSessionCreateRequestDto;
 import com.project.trainingdiary.dto.response.CustomResponse;
+import com.project.trainingdiary.dto.response.WorkoutImageResponseDto;
 import com.project.trainingdiary.dto.response.WorkoutSessionListResponseDto;
 import com.project.trainingdiary.dto.response.WorkoutSessionResponseDto;
 import com.project.trainingdiary.service.WorkoutSessionService;
@@ -64,14 +65,14 @@ public class WorkoutSessionController {
   }
 
   @PutMapping("/workout-sessions/photos")
-  public CustomResponse<?> uploadWorkoutMedia (
+  public CustomResponse<?> uploadWorkoutImage(
       @RequestPart("sessionId") Long sessionId,
       @RequestPart("images") List<MultipartFile> images
   ) throws IOException {
     WorkoutImageRequestDto dto = WorkoutImageRequestDto.builder()
         .sessionId(sessionId).images(images).build();
-    workoutSessionService.uploadWorkoutMedia(dto);
-    return CustomResponse.success();
+    WorkoutImageResponseDto imageResponseDto = workoutSessionService.uploadWorkoutImage(dto);
+    return CustomResponse.success(imageResponseDto);
   }
 
 }

--- a/src/main/java/com/project/trainingdiary/controller/WorkoutSessionController.java
+++ b/src/main/java/com/project/trainingdiary/controller/WorkoutSessionController.java
@@ -66,10 +66,10 @@ public class WorkoutSessionController {
   @PutMapping("/workout-sessions/photos")
   public CustomResponse<?> uploadWorkoutMedia (
       @RequestPart("sessionId") Long sessionId,
-      @RequestPart("mediaFiles") List<MultipartFile> mediaFiles
+      @RequestPart("images") List<MultipartFile> images
   ) throws IOException {
     WorkoutImageRequestDto dto = WorkoutImageRequestDto.builder()
-        .sessionId(sessionId).mediaFiles(mediaFiles).build();
+        .sessionId(sessionId).images(images).build();
     workoutSessionService.uploadWorkoutMedia(dto);
     return CustomResponse.success();
   }

--- a/src/main/java/com/project/trainingdiary/controller/WorkoutSessionController.java
+++ b/src/main/java/com/project/trainingdiary/controller/WorkoutSessionController.java
@@ -1,8 +1,7 @@
 package com.project.trainingdiary.controller;
 
-import com.project.trainingdiary.dto.request.WorkoutMediaRequestDto;
+import com.project.trainingdiary.dto.request.WorkoutImageRequestDto;
 import com.project.trainingdiary.dto.request.WorkoutSessionCreateRequestDto;
-import com.project.trainingdiary.dto.response.CommonResponse;
 import com.project.trainingdiary.dto.response.CustomResponse;
 import com.project.trainingdiary.dto.response.WorkoutSessionListResponseDto;
 import com.project.trainingdiary.dto.response.WorkoutSessionResponseDto;
@@ -69,7 +68,7 @@ public class WorkoutSessionController {
       @RequestPart("sessionId") Long sessionId,
       @RequestPart("mediaFiles") List<MultipartFile> mediaFiles
   ) throws IOException {
-    WorkoutMediaRequestDto dto = WorkoutMediaRequestDto.builder()
+    WorkoutImageRequestDto dto = WorkoutImageRequestDto.builder()
         .sessionId(sessionId).mediaFiles(mediaFiles).build();
     workoutSessionService.uploadWorkoutMedia(dto);
     return CustomResponse.success();

--- a/src/main/java/com/project/trainingdiary/controller/WorkoutSessionController.java
+++ b/src/main/java/com/project/trainingdiary/controller/WorkoutSessionController.java
@@ -1,10 +1,14 @@
 package com.project.trainingdiary.controller;
 
+import com.project.trainingdiary.dto.request.WorkoutMediaRequestDto;
 import com.project.trainingdiary.dto.request.WorkoutSessionCreateRequestDto;
 import com.project.trainingdiary.dto.response.CommonResponse;
+import com.project.trainingdiary.dto.response.CustomResponse;
 import com.project.trainingdiary.dto.response.WorkoutSessionListResponseDto;
 import com.project.trainingdiary.dto.response.WorkoutSessionResponseDto;
 import com.project.trainingdiary.service.WorkoutSessionService;
+import java.io.IOException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -12,11 +16,17 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
+// TODO
+//  1. api 명세 보고 수정
+//  2. path 에 위치한 id를 dto(body)로 받기
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("api/trainees")
@@ -25,15 +35,15 @@ public class WorkoutSessionController {
   private final WorkoutSessionService workoutSessionService;
 
   @PostMapping("/workout-sessions")
-  public CommonResponse<?> createWorkoutSession(
+  public CustomResponse<?> createWorkoutSession(
       @RequestBody WorkoutSessionCreateRequestDto dto
   ) {
     workoutSessionService.createWorkoutSession(dto);
-    return CommonResponse.created();
+    return CustomResponse.success();
   }
 
   @GetMapping("/{id}/workout-sessions")
-  public CommonResponse<?> getWorkoutSessions(
+  public CustomResponse<?> getWorkoutSessions(
       @PathVariable Long id,
       @RequestParam(defaultValue = "0") int page,
       @RequestParam(defaultValue = "10") int size
@@ -41,17 +51,28 @@ public class WorkoutSessionController {
     Pageable pageable = PageRequest.of(page, size);
     Page<WorkoutSessionListResponseDto> responsePage = workoutSessionService
         .getWorkoutSessions(id, pageable);
-    return CommonResponse.success(responsePage);
+    return CustomResponse.success(responsePage);
   }
 
   @GetMapping("/{traineeId}/workout-sessions/{sessionId}")
-  public CommonResponse<?> getWorkoutSessionDetails(
+  public CustomResponse<?> getWorkoutSessionDetails(
       @PathVariable Long traineeId,
       @PathVariable Long sessionId
   ) {
     WorkoutSessionResponseDto responseDto = workoutSessionService
         .getWorkoutSessionDetails(traineeId, sessionId);
-    return CommonResponse.success(responseDto);
+    return CustomResponse.success(responseDto);
+  }
+
+  @PutMapping("/workout-sessions/photos")
+  public CustomResponse<?> uploadWorkoutMedia (
+      @RequestPart("sessionId") Long sessionId,
+      @RequestPart("mediaFiles") List<MultipartFile> mediaFiles
+  ) throws IOException {
+    WorkoutMediaRequestDto dto = WorkoutMediaRequestDto.builder()
+        .sessionId(sessionId).mediaFiles(mediaFiles).build();
+    workoutSessionService.uploadWorkoutMedia(dto);
+    return CustomResponse.success();
   }
 
 }

--- a/src/main/java/com/project/trainingdiary/controller/WorkoutTypeController.java
+++ b/src/main/java/com/project/trainingdiary/controller/WorkoutTypeController.java
@@ -3,6 +3,7 @@ package com.project.trainingdiary.controller;
 import com.project.trainingdiary.dto.request.WorkoutTypeCreateRequestDto;
 import com.project.trainingdiary.dto.request.WorkoutTypeUpdateRequestDto;
 import com.project.trainingdiary.dto.response.CommonResponse;
+import com.project.trainingdiary.dto.response.CustomResponse;
 import com.project.trainingdiary.dto.response.WorkoutTypeResponseDto;
 import com.project.trainingdiary.service.WorkoutTypeService;
 import jakarta.validation.Valid;
@@ -22,7 +23,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 // TODO
-//  로그인 후 운동 종류 다루기 때문에 트레이너 id 넣는 부분 수정 필요
+//  1. 로그인 후 운동 종류 다루기 때문에 트레이너 id 넣는 부분 수정 필요
+//  2. api 명세 보고 수정
+//  3. path 에 위치한 id를 dto(body)로 받기
 
 @RestController
 @RequiredArgsConstructor
@@ -32,42 +35,42 @@ public class WorkoutTypeController {
   private final WorkoutTypeService workoutTypeService;
 
   @PostMapping
-  public CommonResponse<?> createWorkoutType(
+  public CustomResponse<?> createWorkoutType(
       @Valid @RequestBody WorkoutTypeCreateRequestDto dto
   ) {
     workoutTypeService.createWorkoutType(dto);
-    return CommonResponse.created();
+    return CustomResponse.success();
   }
 
   @PutMapping("/{id}")
-  public CommonResponse<?> updateWorkoutType(
+  public CustomResponse<?> updateWorkoutType(
       @PathVariable Long id,
       @Valid @RequestBody WorkoutTypeUpdateRequestDto dto
   ) {
     workoutTypeService.updateWorkoutType(1L, id, dto);
-    return CommonResponse.success();
+    return CustomResponse.success();
   }
 
   @DeleteMapping("/{id}")
-  public CommonResponse<?> deleteWorkoutType(@PathVariable Long id) {
+  public CustomResponse<?> deleteWorkoutType(@PathVariable Long id) {
     workoutTypeService.deleteWorkoutType(1L, id);
-    return CommonResponse.success();
+    return CustomResponse.success();
   }
 
   @GetMapping
-  public CommonResponse<?> getWorkoutTypes(
+  public CustomResponse<?> getWorkoutTypes(
       @RequestParam(defaultValue = "0") int page,
       @RequestParam(defaultValue = "10") int size
   ) {
     Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Order.desc("createdAt")));
     Page<WorkoutTypeResponseDto> responsePage = workoutTypeService.getWorkoutTypes(1L, pageable);
-    return CommonResponse.success(responsePage);
+    return CustomResponse.success(responsePage);
   }
 
   @GetMapping("/{id}")
-  public CommonResponse<?> getWorkoutTypeDetails(@PathVariable Long id) {
+  public CustomResponse<?> getWorkoutTypeDetails(@PathVariable Long id) {
     WorkoutTypeResponseDto responseDto = workoutTypeService.getWorkoutTypeDetails(1L, id);
-    return CommonResponse.created(responseDto);
+    return CustomResponse.success(responseDto);
   }
 
 }

--- a/src/main/java/com/project/trainingdiary/controller/WorkoutTypeController.java
+++ b/src/main/java/com/project/trainingdiary/controller/WorkoutTypeController.java
@@ -2,7 +2,6 @@ package com.project.trainingdiary.controller;
 
 import com.project.trainingdiary.dto.request.WorkoutTypeCreateRequestDto;
 import com.project.trainingdiary.dto.request.WorkoutTypeUpdateRequestDto;
-import com.project.trainingdiary.dto.response.CommonResponse;
 import com.project.trainingdiary.dto.response.CustomResponse;
 import com.project.trainingdiary.dto.response.WorkoutTypeResponseDto;
 import com.project.trainingdiary.service.WorkoutTypeService;

--- a/src/main/java/com/project/trainingdiary/dto/request/WorkoutImageRequestDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/request/WorkoutImageRequestDto.java
@@ -13,7 +13,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class WorkoutMediaRequestDto {
+public class WorkoutImageRequestDto {
 
   private Long sessionId;
   private List<MultipartFile> mediaFiles;

--- a/src/main/java/com/project/trainingdiary/dto/request/WorkoutImageRequestDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/request/WorkoutImageRequestDto.java
@@ -16,6 +16,6 @@ import org.springframework.web.multipart.MultipartFile;
 public class WorkoutImageRequestDto {
 
   private Long sessionId;
-  private List<MultipartFile> mediaFiles;
+  private List<MultipartFile> images;
 
 }

--- a/src/main/java/com/project/trainingdiary/dto/request/WorkoutMediaRequestDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/request/WorkoutMediaRequestDto.java
@@ -1,0 +1,21 @@
+package com.project.trainingdiary.dto.request;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class WorkoutMediaRequestDto {
+
+  private Long sessionId;
+  private List<MultipartFile> mediaFiles;
+
+}

--- a/src/main/java/com/project/trainingdiary/dto/response/WorkoutImageResponseDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/response/WorkoutImageResponseDto.java
@@ -1,0 +1,33 @@
+package com.project.trainingdiary.dto.response;
+
+import com.project.trainingdiary.entity.WorkoutMediaEntity;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class WorkoutImageResponseDto {
+
+  private Long sessionId;
+  private List<String> originalUrls;
+  private List<String> thumbnailUrls;
+
+  public static WorkoutImageResponseDto fromEntity(List<WorkoutMediaEntity> workoutMediaList,
+      Long sessionId) {
+
+    return WorkoutImageResponseDto.builder()
+        .sessionId(sessionId)
+        .originalUrls(workoutMediaList.stream().map(WorkoutMediaEntity::getOriginalUrl).toList())
+        .thumbnailUrls(workoutMediaList.stream().map(WorkoutMediaEntity::getThumbnailUrl).toList())
+        .build();
+
+  }
+
+}

--- a/src/main/java/com/project/trainingdiary/dto/response/WorkoutImageResponseDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/response/WorkoutImageResponseDto.java
@@ -19,8 +19,10 @@ public class WorkoutImageResponseDto {
   private List<String> originalUrls;
   private List<String> thumbnailUrls;
 
-  public static WorkoutImageResponseDto fromEntity(List<WorkoutMediaEntity> workoutMediaList,
-      Long sessionId) {
+  public static WorkoutImageResponseDto fromEntity(
+      List<WorkoutMediaEntity> workoutMediaList,
+      Long sessionId
+  ) {
 
     return WorkoutImageResponseDto.builder()
         .sessionId(sessionId)

--- a/src/main/java/com/project/trainingdiary/dto/response/WorkoutSessionResponseDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/response/WorkoutSessionResponseDto.java
@@ -37,12 +37,12 @@ public class WorkoutSessionResponseDto {
 
     List<String> photoUrls = entity.getWorkoutMedia().stream()
         .filter(media -> media.getMediaType() == IMAGE)
-        .map(WorkoutMediaEntity::getMediaUrl)
+        .map(WorkoutMediaEntity::getOriginalKey)
         .toList();
 
     List<String> videoUrls = entity.getWorkoutMedia().stream()
         .filter(media -> media.getMediaType() == VIDEO)
-        .map(WorkoutMediaEntity::getMediaUrl)
+        .map(WorkoutMediaEntity::getOriginalKey)
         .toList();
 
     return WorkoutSessionResponseDto.builder()

--- a/src/main/java/com/project/trainingdiary/dto/response/WorkoutSessionResponseDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/response/WorkoutSessionResponseDto.java
@@ -37,12 +37,12 @@ public class WorkoutSessionResponseDto {
 
     List<String> photoUrls = entity.getWorkoutMedia().stream()
         .filter(media -> media.getMediaType() == IMAGE)
-        .map(WorkoutMediaEntity::getOriginalKey)
+        .map(WorkoutMediaEntity::getOriginalUrl)
         .toList();
 
     List<String> videoUrls = entity.getWorkoutMedia().stream()
         .filter(media -> media.getMediaType() == VIDEO)
-        .map(WorkoutMediaEntity::getOriginalKey)
+        .map(WorkoutMediaEntity::getOriginalUrl)
         .toList();
 
     return WorkoutSessionResponseDto.builder()

--- a/src/main/java/com/project/trainingdiary/entity/WorkoutMediaEntity.java
+++ b/src/main/java/com/project/trainingdiary/entity/WorkoutMediaEntity.java
@@ -1,11 +1,14 @@
 package com.project.trainingdiary.entity;
 
+import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
 import com.project.trainingdiary.model.WorkoutMediaType;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import java.time.LocalDate;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,8 +27,12 @@ public class WorkoutMediaEntity extends BaseEntity {
   @GeneratedValue(strategy = IDENTITY)
   private Long id;
 
-  private String mediaUrl;
+  private LocalDate uploadDate;
 
+  private String thumbnailKey;
+  private String originalKey;
+
+  @Enumerated(value = STRING)
   private WorkoutMediaType mediaType;
 
 }

--- a/src/main/java/com/project/trainingdiary/entity/WorkoutMediaEntity.java
+++ b/src/main/java/com/project/trainingdiary/entity/WorkoutMediaEntity.java
@@ -26,8 +26,8 @@ public class WorkoutMediaEntity extends BaseEntity {
   @GeneratedValue(strategy = IDENTITY)
   private Long id;
 
-  private String thumbnailKey;
-  private String originalKey;
+  private String originalUrl;
+  private String thumbnailUrl;
 
   @Enumerated(value = STRING)
   private WorkoutMediaType mediaType;

--- a/src/main/java/com/project/trainingdiary/entity/WorkoutMediaEntity.java
+++ b/src/main/java/com/project/trainingdiary/entity/WorkoutMediaEntity.java
@@ -8,7 +8,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
-import java.time.LocalDate;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -26,8 +25,6 @@ public class WorkoutMediaEntity extends BaseEntity {
   @Id
   @GeneratedValue(strategy = IDENTITY)
   private Long id;
-
-  private LocalDate uploadDate;
 
   private String thumbnailKey;
   private String originalKey;

--- a/src/main/java/com/project/trainingdiary/entity/WorkoutSessionEntity.java
+++ b/src/main/java/com/project/trainingdiary/entity/WorkoutSessionEntity.java
@@ -1,5 +1,6 @@
 package com.project.trainingdiary.entity;
 
+import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
 import com.project.trainingdiary.dto.request.WorkoutSessionCreateRequestDto;
@@ -18,7 +19,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
-@Builder
+@Builder(toBuilder = true)
 @Getter
 @ToString
 @NoArgsConstructor
@@ -45,7 +46,7 @@ public class WorkoutSessionEntity extends BaseEntity {
   @JoinColumn(name = "workout_session_id")
   private List<WorkoutMediaEntity> workoutMedia;
 
-  @ManyToOne
+  @ManyToOne(fetch = LAZY)
   @JoinColumn(name = "pt_contract_id")
   private PtContractEntity ptContract;
 

--- a/src/main/java/com/project/trainingdiary/exception/impl/InvalidFileTypeException.java
+++ b/src/main/java/com/project/trainingdiary/exception/impl/InvalidFileTypeException.java
@@ -1,0 +1,11 @@
+package com.project.trainingdiary.exception.impl;
+
+import com.project.trainingdiary.exception.GlobalException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidFileTypeException extends GlobalException {
+
+  public InvalidFileTypeException() {
+    super(HttpStatus.BAD_REQUEST, "유효하지 않은 미디어 타입 입니다.");
+  }
+}

--- a/src/main/java/com/project/trainingdiary/exception/impl/MediaCountExceededException.java
+++ b/src/main/java/com/project/trainingdiary/exception/impl/MediaCountExceededException.java
@@ -1,0 +1,11 @@
+package com.project.trainingdiary.exception.impl;
+
+import com.project.trainingdiary.exception.GlobalException;
+import org.springframework.http.HttpStatus;
+
+public class MediaCountExceededException extends GlobalException {
+
+  public MediaCountExceededException() {
+    super(HttpStatus.BAD_REQUEST, "미디어 업로드 개수는 각 10개를 넘길 수 없습니다.");
+  }
+}

--- a/src/main/java/com/project/trainingdiary/repository/WorkoutSessionRepository.java
+++ b/src/main/java/com/project/trainingdiary/repository/WorkoutSessionRepository.java
@@ -1,5 +1,6 @@
 package com.project.trainingdiary.repository;
 
+import com.project.trainingdiary.entity.TrainerEntity;
 import com.project.trainingdiary.entity.WorkoutSessionEntity;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -12,5 +13,7 @@ public interface WorkoutSessionRepository extends JpaRepository<WorkoutSessionEn
       Pageable pageable);
 
   Optional<WorkoutSessionEntity> findByIdAndPtContract_Trainee_Id(Long sessionId, Long traineeId);
+
+  Optional<WorkoutSessionEntity> findByPtContract_TrainerAndId(TrainerEntity trainer, Long sessionId);
 
 }

--- a/src/main/java/com/project/trainingdiary/repository/WorkoutSessionRepository.java
+++ b/src/main/java/com/project/trainingdiary/repository/WorkoutSessionRepository.java
@@ -14,6 +14,7 @@ public interface WorkoutSessionRepository extends JpaRepository<WorkoutSessionEn
 
   Optional<WorkoutSessionEntity> findByIdAndPtContract_Trainee_Id(Long sessionId, Long traineeId);
 
-  Optional<WorkoutSessionEntity> findByPtContract_TrainerAndId(TrainerEntity trainer, Long sessionId);
+  Optional<WorkoutSessionEntity> findByPtContract_TrainerAndId(TrainerEntity trainer,
+      Long sessionId);
 
 }

--- a/src/main/java/com/project/trainingdiary/security/SecurityConfig.java
+++ b/src/main/java/com/project/trainingdiary/security/SecurityConfig.java
@@ -37,6 +37,7 @@ public class SecurityConfig {
             .permitAll() // Swagger UI
             .requestMatchers("/api/pt-contracts/**").authenticated()
             .requestMatchers("/api/schedules/**").authenticated()
+            .requestMatchers("/api/trainees/**", "api/trainers/**").authenticated()
             .anyRequest().authenticated())
         .exceptionHandling(exception -> exception
             .authenticationEntryPoint(new FailedAuthenticationEntryPoint()))

--- a/src/main/java/com/project/trainingdiary/service/WorkoutSessionService.java
+++ b/src/main/java/com/project/trainingdiary/service/WorkoutSessionService.java
@@ -1,28 +1,50 @@
 package com.project.trainingdiary.service;
 
+import static com.project.trainingdiary.model.WorkoutMediaType.IMAGE;
+
+import com.project.trainingdiary.dto.request.WorkoutMediaRequestDto;
 import com.project.trainingdiary.dto.request.WorkoutSessionCreateRequestDto;
 import com.project.trainingdiary.dto.response.WorkoutSessionListResponseDto;
 import com.project.trainingdiary.dto.response.WorkoutSessionResponseDto;
 import com.project.trainingdiary.entity.PtContractEntity;
 import com.project.trainingdiary.entity.TrainerEntity;
 import com.project.trainingdiary.entity.WorkoutEntity;
+import com.project.trainingdiary.entity.WorkoutMediaEntity;
 import com.project.trainingdiary.entity.WorkoutSessionEntity;
 import com.project.trainingdiary.entity.WorkoutTypeEntity;
+import com.project.trainingdiary.exception.impl.InvalidFileTypeException;
+import com.project.trainingdiary.exception.impl.MediaCountExceededException;
 import com.project.trainingdiary.exception.impl.PtContractNotFoundException;
 import com.project.trainingdiary.exception.impl.UserNotFoundException;
 import com.project.trainingdiary.exception.impl.WorkoutSessionNotFoundException;
 import com.project.trainingdiary.exception.impl.WorkoutTypeNotFoundException;
 import com.project.trainingdiary.repository.PtContractRepository;
 import com.project.trainingdiary.repository.TrainerRepository;
+import com.project.trainingdiary.repository.WorkoutMediaRepository;
 import com.project.trainingdiary.repository.WorkoutRepository;
 import com.project.trainingdiary.repository.WorkoutSessionRepository;
 import com.project.trainingdiary.repository.WorkoutTypeRepository;
+import io.awspring.cloud.s3.ObjectMetadata;
+import io.awspring.cloud.s3.S3Operations;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.List;
+import java.util.UUID;
+import javax.imageio.ImageIO;
 import lombok.RequiredArgsConstructor;
+import org.imgscalr.Scalr;
+import org.imgscalr.Scalr.Method;
+import org.imgscalr.Scalr.Mode;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -31,21 +53,30 @@ public class WorkoutSessionService {
   private final WorkoutTypeRepository workoutTypeRepository;
   private final WorkoutSessionRepository workoutSessionRepository;
   private final WorkoutRepository workoutRepository;
+  private final WorkoutMediaRepository workoutMediaRepository;
   private final TrainerRepository trainerRepository;
   private final PtContractRepository ptContractRepository;
+
+  private final S3Operations s3Operations;
+
+  private static final int MAX_MEDIA_COUNT = 10;
+
+  @Value("${spring.cloud.aws.s3.bucket}")
+  private String bucket;
 
   /**
    * 트레이너의 운동 일지 생성
    */
   public void createWorkoutSession(WorkoutSessionCreateRequestDto dto) {
-    TrainerEntity trainer = trainerRepository
-        .findByEmail(SecurityContextHolder.getContext().getAuthentication().getName())
-        .orElseThrow(UserNotFoundException::new);
+    // 현재 로그인 되어있는 트레이너 본인의 엔티티
+    TrainerEntity trainer = getTrainer();
 
+    // 트레이너와 트레이니간의 PT 계약이 존재하는지 확인
     PtContractEntity ptContract = ptContractRepository
         .findByTrainerIdAndTraineeId(trainer.getId(), dto.getTraineeId())
         .orElseThrow(PtContractNotFoundException::new);
 
+    // 운동 일지에서 운동 상세 내용(workout)은 운동 엔티티에 저장
     List<WorkoutEntity> workouts = dto.getWorkouts().stream().map(details -> {
       WorkoutTypeEntity workoutType = workoutTypeRepository.findById(details.getWorkoutTypeId())
           .orElseThrow(() -> new WorkoutTypeNotFoundException(details.getWorkoutTypeId()));
@@ -54,7 +85,14 @@ public class WorkoutSessionService {
       return workout;
     }).toList();
 
+    //  운동 일지 엔티티 저장
     workoutSessionRepository.save(WorkoutSessionEntity.toEntity(dto, workouts, ptContract));
+  }
+
+  private TrainerEntity getTrainer() {
+    return trainerRepository
+        .findByEmail(SecurityContextHolder.getContext().getAuthentication().getName())
+        .orElseThrow(UserNotFoundException::new);
   }
 
   /**
@@ -66,6 +104,8 @@ public class WorkoutSessionService {
         .map(WorkoutSessionListResponseDto::fromEntity);
   }
 
+  // TODO
+  //  상세 조회 시에 key 가져와서 url 반환하는 로직 추가
   /**
    * 운동 일지 상세 조회
    */
@@ -75,5 +115,73 @@ public class WorkoutSessionService {
         .orElseThrow(() -> new WorkoutSessionNotFoundException(sessionId));
     return WorkoutSessionResponseDto.fromEntity(session);
   }
+
+  /**
+   * 운동 일지 - 이미지 업로드
+   */
+  public void uploadWorkoutMedia(WorkoutMediaRequestDto dto) throws IOException {
+    TrainerEntity trainer = getTrainer();
+
+    // 이미지를 업로드할 운동 일지가 존재하는지 확인
+    WorkoutSessionEntity workoutSession = workoutSessionRepository.findByPtContract_TrainerAndId(trainer, dto.getSessionId())
+        .orElseThrow(() -> new WorkoutSessionNotFoundException(dto.getSessionId()));
+
+    int existingImageCount = (int) workoutSession.getWorkoutMedia().stream()
+        .filter(media -> media.getMediaType() == IMAGE).count();
+    int newImageCount = dto.getMediaFiles().size();
+
+    // 현재 운동 일지에 존재하는 이미지와 새로 받은 이미지의 합이 10을 넘으면 예외 발생 - 이미지는 최대 10개까지 업로드 가능
+    if (existingImageCount + newImageCount > MAX_MEDIA_COUNT) {
+      throw new MediaCountExceededException();
+    }
+
+    // 이미지 확인
+    for (MultipartFile file : dto.getMediaFiles()) {
+      if (!isValidImageType(file)) {
+        throw new InvalidFileTypeException();
+      }
+
+      // key (이미지 이름) 설정 후 업로드
+      String originalKey = UUID.randomUUID().toString();
+      try (InputStream inputStream = file.getInputStream()){
+        s3Operations.upload(bucket, originalKey, inputStream,
+            ObjectMetadata.builder().contentType(file.getContentType()).build());
+      }
+
+      // 썸네일 생성 후 업로드
+      String thumbnailKey = createAndUploadThumbnail(file, originalKey);
+
+      WorkoutMediaEntity workoutMedia = WorkoutMediaEntity.builder()
+          .originalKey(originalKey).thumbnailKey(thumbnailKey).mediaType(IMAGE).build();
+
+      workoutMediaRepository.save(workoutMedia);
+      workoutSession.getWorkoutMedia().add(workoutMedia);
+    }
+    workoutSessionRepository.save(workoutSession);
+  }
+
+  private String createAndUploadThumbnail(MultipartFile file, String originalKey) throws IOException {
+    BufferedImage originalImage = ImageIO.read(file.getInputStream());
+    BufferedImage thumbnailImage = Scalr.resize(originalImage, Method.QUALITY, Mode.AUTOMATIC, 150, 150);
+
+    try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream()) {
+      ImageIO.write(thumbnailImage, "jpg", byteArrayOutputStream);
+      try (InputStream inputStream = new ByteArrayInputStream(byteArrayOutputStream.toByteArray())) {
+        String thumbnailKey = "thumb_" + originalKey;
+        s3Operations.upload(bucket, thumbnailKey, inputStream, ObjectMetadata.builder().contentType(MediaType.IMAGE_JPEG_VALUE).build());
+        return thumbnailKey;
+      }
+    }
+  }
+
+  /**
+   * 이미지 확인 - jpeg, png 가능
+   */
+  private boolean isValidImageType(MultipartFile file) {
+    return MediaType.IMAGE_JPEG.toString().equals(file.getContentType()) ||
+        MediaType.IMAGE_PNG.toString().equals(file.getContentType());
+  }
+
+
 
 }

--- a/src/main/java/com/project/trainingdiary/service/WorkoutSessionService.java
+++ b/src/main/java/com/project/trainingdiary/service/WorkoutSessionService.java
@@ -2,7 +2,7 @@ package com.project.trainingdiary.service;
 
 import static com.project.trainingdiary.model.WorkoutMediaType.IMAGE;
 
-import com.project.trainingdiary.dto.request.WorkoutMediaRequestDto;
+import com.project.trainingdiary.dto.request.WorkoutImageRequestDto;
 import com.project.trainingdiary.dto.request.WorkoutSessionCreateRequestDto;
 import com.project.trainingdiary.dto.response.WorkoutSessionListResponseDto;
 import com.project.trainingdiary.dto.response.WorkoutSessionResponseDto;
@@ -119,7 +119,7 @@ public class WorkoutSessionService {
   /**
    * 운동 일지 - 이미지 업로드
    */
-  public void uploadWorkoutMedia(WorkoutMediaRequestDto dto) throws IOException {
+  public void uploadWorkoutMedia(WorkoutImageRequestDto dto) throws IOException {
     TrainerEntity trainer = getTrainer();
 
     // 이미지를 업로드할 운동 일지가 존재하는지 확인
@@ -181,7 +181,6 @@ public class WorkoutSessionService {
     return MediaType.IMAGE_JPEG.toString().equals(file.getContentType()) ||
         MediaType.IMAGE_PNG.toString().equals(file.getContentType());
   }
-
 
 
 }

--- a/src/main/java/com/project/trainingdiary/service/WorkoutSessionService.java
+++ b/src/main/java/com/project/trainingdiary/service/WorkoutSessionService.java
@@ -136,8 +136,10 @@ public class WorkoutSessionService {
         throw new InvalidFileTypeException();
       }
 
+      // 확장자 추출
+      String extension = getExtension(file.getOriginalFilename());
       // key (이미지 이름) 설정 후 업로드
-      String originalKey = UUID.randomUUID().toString();
+      String originalKey = UUID.randomUUID() + "." + extension;
       S3Resource s3Resource;
       try (InputStream inputStream = file.getInputStream()) {
         s3Resource = s3Operations.upload(bucket, originalKey, inputStream,
@@ -189,6 +191,17 @@ public class WorkoutSessionService {
   private boolean isValidImageType(MultipartFile file) {
     return MediaType.IMAGE_JPEG.toString().equals(file.getContentType()) ||
         MediaType.IMAGE_PNG.toString().equals(file.getContentType());
+  }
+
+  /**
+   * 확장자 추출
+   */
+  private String getExtension(String filename) {
+    if (filename == null) {
+      return "";
+    }
+    int dotIndex = filename.lastIndexOf('.');
+    return (dotIndex == -1) ? "" : filename.substring(dotIndex + 1);
   }
 
   /**

--- a/src/main/java/com/project/trainingdiary/service/WorkoutSessionService.java
+++ b/src/main/java/com/project/trainingdiary/service/WorkoutSessionService.java
@@ -89,12 +89,6 @@ public class WorkoutSessionService {
     workoutSessionRepository.save(WorkoutSessionEntity.toEntity(dto, workouts, ptContract));
   }
 
-  private TrainerEntity getTrainer() {
-    return trainerRepository
-        .findByEmail(SecurityContextHolder.getContext().getAuthentication().getName())
-        .orElseThrow(UserNotFoundException::new);
-  }
-
   /**
    * 운동 일지 목록 조회
    */
@@ -128,7 +122,7 @@ public class WorkoutSessionService {
 
     int existingImageCount = (int) workoutSession.getWorkoutMedia().stream()
         .filter(media -> media.getMediaType() == IMAGE).count();
-    int newImageCount = dto.getMediaFiles().size();
+    int newImageCount = dto.getImages().size();
 
     // 현재 운동 일지에 존재하는 이미지와 새로 받은 이미지의 합이 10을 넘으면 예외 발생 - 이미지는 최대 10개까지 업로드 가능
     if (existingImageCount + newImageCount > MAX_MEDIA_COUNT) {
@@ -136,7 +130,7 @@ public class WorkoutSessionService {
     }
 
     // 이미지 확인
-    for (MultipartFile file : dto.getMediaFiles()) {
+    for (MultipartFile file : dto.getImages()) {
       if (!isValidImageType(file)) {
         throw new InvalidFileTypeException();
       }
@@ -182,5 +176,10 @@ public class WorkoutSessionService {
         MediaType.IMAGE_PNG.toString().equals(file.getContentType());
   }
 
+  private TrainerEntity getTrainer() {
+    return trainerRepository
+        .findByEmail(SecurityContextHolder.getContext().getAuthentication().getName())
+        .orElseThrow(UserNotFoundException::new);
+  }
 
 }

--- a/src/main/resources/application-sample.yml
+++ b/src/main/resources/application-sample.yml
@@ -4,11 +4,13 @@ spring:
     driver-class-name: org.mariadb.jdbc.Driver
     username:
     password:
+
   jpa:
     generate-ddl: true
     hibernate:
       ddl-auto: update
     show-sql: true
+
   mail:
     host: smtp.gmail.com
     port: 587
@@ -22,3 +24,15 @@ spring:
           auth: true
   jwt:
     secret:
+
+  cloud:
+    aws:
+      credentials:
+        access-key:
+        secret-key:
+      region:
+        static:
+      s3:
+        bucket:
+      stack:
+        auto: false

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,5 @@
+spring:
+  cloud:
+    aws:
+      s3:
+        bucket: test-bucket

--- a/src/test/java/com/project/trainingdiary/service/WorkoutSessionServiceTest.java
+++ b/src/test/java/com/project/trainingdiary/service/WorkoutSessionServiceTest.java
@@ -1,14 +1,18 @@
 package com.project.trainingdiary.service;
 
 import static com.project.trainingdiary.model.UserRoleType.TRAINEE;
+import static com.project.trainingdiary.model.WorkoutMediaType.IMAGE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.project.trainingdiary.dto.request.WorkoutDto;
+import com.project.trainingdiary.dto.request.WorkoutMediaRequestDto;
 import com.project.trainingdiary.dto.request.WorkoutSessionCreateRequestDto;
 import com.project.trainingdiary.dto.response.WorkoutSessionListResponseDto;
 import com.project.trainingdiary.dto.response.WorkoutSessionResponseDto;
@@ -16,21 +20,33 @@ import com.project.trainingdiary.entity.PtContractEntity;
 import com.project.trainingdiary.entity.TraineeEntity;
 import com.project.trainingdiary.entity.TrainerEntity;
 import com.project.trainingdiary.entity.WorkoutEntity;
+import com.project.trainingdiary.entity.WorkoutMediaEntity;
 import com.project.trainingdiary.entity.WorkoutSessionEntity;
 import com.project.trainingdiary.entity.WorkoutTypeEntity;
+import com.project.trainingdiary.exception.impl.InvalidFileTypeException;
+import com.project.trainingdiary.exception.impl.MediaCountExceededException;
 import com.project.trainingdiary.exception.impl.PtContractNotFoundException;
 import com.project.trainingdiary.exception.impl.UserNotFoundException;
 import com.project.trainingdiary.exception.impl.WorkoutSessionNotFoundException;
 import com.project.trainingdiary.exception.impl.WorkoutTypeNotFoundException;
 import com.project.trainingdiary.repository.PtContractRepository;
 import com.project.trainingdiary.repository.TrainerRepository;
+import com.project.trainingdiary.repository.WorkoutMediaRepository;
 import com.project.trainingdiary.repository.WorkoutRepository;
 import com.project.trainingdiary.repository.WorkoutSessionRepository;
 import com.project.trainingdiary.repository.WorkoutTypeRepository;
+import io.awspring.cloud.s3.ObjectMetadata;
+import io.awspring.cloud.s3.S3Operations;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -39,17 +55,24 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.TestPropertySource;
 
 @ExtendWith(MockitoExtension.class)
+@TestPropertySource("classpath:application-test.yml")
 class WorkoutSessionServiceTest {
+
+  @Value("${spring.cloud.aws.s3.bucket}")
+  private String bucket;
 
   @Mock
   private TrainerRepository trainerRepository;
@@ -66,6 +89,12 @@ class WorkoutSessionServiceTest {
   @Mock
   private WorkoutSessionRepository workoutSessionRepository;
 
+  @Mock
+  private WorkoutMediaRepository workoutMediaRepository;
+
+  @Mock
+  private S3Operations s3Operations;
+
   @InjectMocks
   private WorkoutSessionService workoutSessionService;
 
@@ -76,7 +105,7 @@ class WorkoutSessionServiceTest {
   private WorkoutSessionEntity workoutSession;
 
   @BeforeEach
-  public void init() {
+  void init() {
     Authentication authentication = new TestingAuthenticationToken("trainer@gmail.com", null,
         Collections.singletonList(new SimpleGrantedAuthority("ROLE_TRAINER")));
     SecurityContextHolder.getContext().setAuthentication(authentication);
@@ -87,13 +116,18 @@ class WorkoutSessionServiceTest {
         .trainee(trainee).build();
     workoutType = WorkoutTypeEntity.builder().id(1000L).name("WorkoutType").build();
     workoutSession = WorkoutSessionEntity.builder().id(10000L).sessionDate(LocalDate.now())
-        .sessionNumber(1).ptContract(ptContract).workouts(Collections.emptyList())
-        .workoutMedia(Collections.emptyList()).build();
+        .sessionNumber(1).ptContract(ptContract).workouts(new ArrayList<>())
+        .workoutMedia(new ArrayList<>()).build();
+  }
+
+  @AfterEach
+  void cleanup() {
+    SecurityContextHolder.clearContext();
   }
 
   @Test
   @DisplayName("운동 일지 생성 성공")
-  public void testCreateWorkoutSessionSuccess() {
+  void testCreateWorkoutSessionSuccess() {
     when(trainerRepository.findByEmail("trainer@gmail.com")).thenReturn(Optional.of(trainer));
     when(ptContractRepository.findByTrainerIdAndTraineeId(trainer.getId(), trainee.getId()))
         .thenReturn(Optional.of(ptContract));
@@ -122,7 +156,7 @@ class WorkoutSessionServiceTest {
 
   @Test
   @DisplayName("운동 일지 생성 실패 - 트레이너를 찾지 못할 때 예외 발생")
-  public void testCreateWorkoutSessionFailTrainerNotFound() {
+  void testCreateWorkoutSessionFailTrainerNotFound() {
     when(trainerRepository.findByEmail("trainer@gmail.com")).thenReturn(Optional.empty());
 
     WorkoutDto workoutDto = new WorkoutDto();
@@ -142,7 +176,7 @@ class WorkoutSessionServiceTest {
 
   @Test
   @DisplayName("운동 일지 생성 실패 - PT 계약이 존재 하지 않을 때 예외 발생")
-  public void testCreateWorkoutSessionFailPtContractNotFound() {
+  void testCreateWorkoutSessionFailPtContractNotFound() {
     when(trainerRepository.findByEmail("trainer@gmail.com")).thenReturn(Optional.of(trainer));
     when(ptContractRepository.findByTrainerIdAndTraineeId(trainer.getId(), 10L))
         .thenReturn(Optional.empty());
@@ -164,7 +198,7 @@ class WorkoutSessionServiceTest {
 
   @Test
   @DisplayName("운동 일지 생성 실패 - 운동 종류가 존재 하지 않을 때 예외 발생")
-  public void testCreateWorkoutSessionFailWorkoutTypeNotFound() {
+  void testCreateWorkoutSessionFailWorkoutTypeNotFound() {
     when(trainerRepository.findByEmail("trainer@gmail.com")).thenReturn(Optional.of(trainer));
     when(ptContractRepository.findByTrainerIdAndTraineeId(trainer.getId(), 10L))
         .thenReturn(Optional.of(ptContract));
@@ -188,7 +222,7 @@ class WorkoutSessionServiceTest {
 
   @Test
   @DisplayName("운동 일지 목록 조회 성공")
-  public void testGetWorkoutSessionsSuccess() {
+  void testGetWorkoutSessionsSuccess() {
     Pageable pageable = PageRequest.of(0, 10);
 
     when(workoutSessionRepository
@@ -207,7 +241,7 @@ class WorkoutSessionServiceTest {
 
   @Test
   @DisplayName("운동 일지 목록 조회 실패 - 트레이니를 찾지 못할 때 예외 발생")
-  public void testGetWorkoutSessionsFailInvalidTraineeId() {
+  void testGetWorkoutSessionsFailInvalidTraineeId() {
     Pageable pageable = PageRequest.of(0, 10);
 
     when(workoutSessionRepository
@@ -225,7 +259,7 @@ class WorkoutSessionServiceTest {
 
   @Test
   @DisplayName("운동 일지 상세 조회 성공")
-  public void testGetWorkoutSessionDetailsSuccess() {
+  void testGetWorkoutSessionDetailsSuccess() {
     when(workoutSessionRepository
         .findByIdAndPtContract_Trainee_Id(workoutSession.getId(), trainee.getId()))
         .thenReturn(Optional.of(workoutSession));
@@ -243,7 +277,7 @@ class WorkoutSessionServiceTest {
 
   @Test
   @DisplayName("운동 일지 상세 조회 실패 - 운동 일지가 존재하지 않을 때 예외 발생")
-  public void testGetWorkoutSessionDetailsFailInvalidSessionId() {
+  void testGetWorkoutSessionDetailsFailInvalidSessionId() {
     when(workoutSessionRepository.findByIdAndPtContract_Trainee_Id(1L, trainee.getId()))
         .thenReturn(Optional.empty());
 
@@ -252,6 +286,146 @@ class WorkoutSessionServiceTest {
 
     verify(workoutSessionRepository, times(1))
         .findByIdAndPtContract_Trainee_Id(1L, trainee.getId());
+  }
+
+  @Test
+  @DisplayName("이미지 업로드 성공")
+  void testUploadWorkoutMediaSuccess() throws IOException {
+    when(trainerRepository.findByEmail("trainer@gmail.com")).thenReturn(Optional.of(trainer));
+    when(workoutSessionRepository.findByPtContract_TrainerAndId(trainer, 10000L))
+        .thenReturn(Optional.of(workoutSession));
+
+    // 다운로드 폴더에서 테스트 이미지 파일 읽기
+    byte[] imageBytes = Files.readAllBytes(
+        Paths.get(System.getProperty("user.home") + "/Downloads/test.jpeg"));
+    MockMultipartFile mockFile = new MockMultipartFile(
+        "file", "test.jpg", "image/jpeg", imageBytes
+    );
+
+    WorkoutMediaRequestDto dto = WorkoutMediaRequestDto.builder()
+        .sessionId(10000L)
+        .mediaFiles(List.of(mockFile))
+        .build();
+
+    workoutSessionService.uploadWorkoutMedia(dto);
+
+    ArgumentCaptor<WorkoutMediaEntity> mediaCaptor = ArgumentCaptor.forClass(
+        WorkoutMediaEntity.class);
+    verify(workoutMediaRepository, times(1)).save(mediaCaptor.capture());
+    WorkoutMediaEntity savedMedia = mediaCaptor.getValue();
+    assertEquals("IMAGE", savedMedia.getMediaType().name());
+
+    ArgumentCaptor<String> bucketCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<InputStream> inputStreamCaptor = ArgumentCaptor.forClass(InputStream.class);
+    ArgumentCaptor<ObjectMetadata> metadataCaptor = ArgumentCaptor.forClass(ObjectMetadata.class);
+
+    verify(s3Operations, times(2)).upload(
+        bucketCaptor.capture(), keyCaptor.capture(), inputStreamCaptor.capture(),
+        metadataCaptor.capture());
+
+    List<String> capturedBuckets = bucketCaptor.getAllValues();
+    List<String> capturedKeys = keyCaptor.getAllValues();
+
+    // 디버깅을 위해 캡처된 키 값들을 출력
+    System.out.println("Captured Keys: " + capturedKeys);
+
+    assertEquals(bucket, capturedBuckets.get(0));
+    assertTrue(capturedKeys.stream().anyMatch(key -> key.startsWith("thumb_")));
+
+    ArgumentCaptor<WorkoutSessionEntity> sessionCaptor = ArgumentCaptor.forClass(
+        WorkoutSessionEntity.class);
+    verify(workoutSessionRepository, times(1)).save(sessionCaptor.capture());
+    WorkoutSessionEntity savedSession = sessionCaptor.getValue();
+    assertEquals(1, savedSession.getWorkoutMedia().size());
+  }
+
+  @Test
+  @DisplayName("이미지 업로드 실패 - 이미지 개수가 10개를 초과하면 예외 발생")
+  void testUploadWorkoutMediaFailExcessiveImages() throws IOException {
+    workoutSession.getWorkoutMedia()
+        .addAll(Collections.nCopies(10, WorkoutMediaEntity.builder().mediaType(IMAGE).build()));
+
+    when(trainerRepository.findByEmail("trainer@gmail.com")).thenReturn(Optional.of(trainer));
+    when(workoutSessionRepository.findByPtContract_TrainerAndId(trainer, 10000L))
+        .thenReturn(Optional.of(workoutSession));
+
+    byte[] imageBytes = Files.readAllBytes(
+        Paths.get(System.getProperty("user.home") + "/Downloads/test.jpeg"));
+    MockMultipartFile mockFile = new MockMultipartFile(
+        "file", "test.jpg", "image/jpeg", imageBytes);
+
+    WorkoutMediaRequestDto dto = WorkoutMediaRequestDto.builder()
+        .sessionId(10000L)
+        .mediaFiles(List.of(mockFile))
+        .build();
+
+    assertThrows(MediaCountExceededException.class,
+        () -> workoutSessionService.uploadWorkoutMedia(dto));
+
+    ArgumentCaptor<WorkoutMediaEntity> mediaCaptor = ArgumentCaptor.forClass(
+        WorkoutMediaEntity.class);
+    ArgumentCaptor<String> bucketCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<InputStream> inputStreamCaptor = ArgumentCaptor.forClass(InputStream.class);
+    ArgumentCaptor<ObjectMetadata> metadataCaptor = ArgumentCaptor.forClass(ObjectMetadata.class);
+    ArgumentCaptor<WorkoutSessionEntity> sessionCaptor = ArgumentCaptor.forClass(
+        WorkoutSessionEntity.class);
+
+    verify(workoutMediaRepository, never()).save(mediaCaptor.capture());
+    verify(s3Operations, never()).upload(
+        bucketCaptor.capture(), keyCaptor.capture(), inputStreamCaptor.capture(),
+        metadataCaptor.capture());
+    verify(workoutSessionRepository, never()).save(sessionCaptor.capture());
+
+    assertTrue(mediaCaptor.getAllValues().isEmpty());
+    assertTrue(bucketCaptor.getAllValues().isEmpty());
+    assertTrue(keyCaptor.getAllValues().isEmpty());
+    assertTrue(inputStreamCaptor.getAllValues().isEmpty());
+    assertTrue(metadataCaptor.getAllValues().isEmpty());
+    assertTrue(sessionCaptor.getAllValues().isEmpty());
+  }
+
+  @Test
+  @DisplayName("이미지 업로드 실패 - 파일 타입이 맞지 않으면 예외 발생")
+  void testUploadWorkoutMediaFailInvalidFileType() {
+    when(trainerRepository.findByEmail("trainer@gmail.com")).thenReturn(Optional.of(trainer));
+    when(workoutSessionRepository.findByPtContract_TrainerAndId(trainer, 10000L))
+        .thenReturn(Optional.of(workoutSession));
+
+    MockMultipartFile mockFile = new MockMultipartFile(
+        "file", "test.txt", "text/plain", "test text content" .getBytes()
+    );
+
+    WorkoutMediaRequestDto dto = WorkoutMediaRequestDto.builder()
+        .sessionId(10000L)
+        .mediaFiles(List.of(mockFile))
+        .build();
+
+    assertThrows(InvalidFileTypeException.class,
+        () -> workoutSessionService.uploadWorkoutMedia(dto));
+
+    ArgumentCaptor<WorkoutMediaEntity> mediaCaptor = ArgumentCaptor.forClass(
+        WorkoutMediaEntity.class);
+    ArgumentCaptor<String> bucketCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<InputStream> inputStreamCaptor = ArgumentCaptor.forClass(InputStream.class);
+    ArgumentCaptor<ObjectMetadata> metadataCaptor = ArgumentCaptor.forClass(ObjectMetadata.class);
+    ArgumentCaptor<WorkoutSessionEntity> sessionCaptor = ArgumentCaptor.forClass(
+        WorkoutSessionEntity.class);
+
+    verify(workoutMediaRepository, never()).save(mediaCaptor.capture());
+    verify(s3Operations, never()).upload(
+        bucketCaptor.capture(), keyCaptor.capture(), inputStreamCaptor.capture(),
+        metadataCaptor.capture());
+    verify(workoutSessionRepository, never()).save(sessionCaptor.capture());
+
+    assertTrue(mediaCaptor.getAllValues().isEmpty());
+    assertTrue(bucketCaptor.getAllValues().isEmpty());
+    assertTrue(keyCaptor.getAllValues().isEmpty());
+    assertTrue(inputStreamCaptor.getAllValues().isEmpty());
+    assertTrue(metadataCaptor.getAllValues().isEmpty());
+    assertTrue(sessionCaptor.getAllValues().isEmpty());
   }
 
 }

--- a/src/test/java/com/project/trainingdiary/service/WorkoutSessionServiceTest.java
+++ b/src/test/java/com/project/trainingdiary/service/WorkoutSessionServiceTest.java
@@ -104,7 +104,6 @@ class WorkoutSessionServiceTest {
   @Mock
   private S3Operations s3Operations;
 
-
   @InjectMocks
   private WorkoutSessionService workoutSessionService;
 
@@ -319,9 +318,9 @@ class WorkoutSessionServiceTest {
     S3Resource s3ResourceThumbnail = mock(S3Resource.class);
 
     when(s3ResourceOriginal.getURL()).thenReturn(
-        new URL("https://test-bucket.s3.amazonaws.com/original"));
+        new URL("https://test-bucket.s3.amazonaws.com/original.jpg"));
     when(s3ResourceThumbnail.getURL()).thenReturn(
-        new URL("https://test-bucket.s3.amazonaws.com/thumbnail"));
+        new URL("https://test-bucket.s3.amazonaws.com/thumb_original.jpg"));
 
     ArgumentCaptor<String> bucketCaptor = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
@@ -350,8 +349,10 @@ class WorkoutSessionServiceTest {
     assertEquals(bucket, capturedBuckets.get(0));
     assertEquals(bucket, capturedBuckets.get(1));
 
-    assertTrue(capturedKeys.get(0).matches("[0-9a-fA-F-]{36}"));
+    // Check that keys contain the correct UUID structure for original and thumbnail
+    assertTrue(capturedKeys.get(0).matches("[0-9a-fA-F-]{36}\\.jpg"));
     assertTrue(capturedKeys.get(1).startsWith("thumb_"));
+    assertTrue(capturedKeys.get(1).matches("thumb_[0-9a-fA-F-]{36}\\.jpg"));
 
     ArgumentCaptor<WorkoutSessionEntity> sessionCaptor = ArgumentCaptor.forClass(
         WorkoutSessionEntity.class);

--- a/src/test/java/com/project/trainingdiary/service/WorkoutSessionServiceTest.java
+++ b/src/test/java/com/project/trainingdiary/service/WorkoutSessionServiceTest.java
@@ -12,7 +12,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.project.trainingdiary.dto.request.WorkoutDto;
-import com.project.trainingdiary.dto.request.WorkoutMediaRequestDto;
+import com.project.trainingdiary.dto.request.WorkoutImageRequestDto;
 import com.project.trainingdiary.dto.request.WorkoutSessionCreateRequestDto;
 import com.project.trainingdiary.dto.response.WorkoutSessionListResponseDto;
 import com.project.trainingdiary.dto.response.WorkoutSessionResponseDto;
@@ -302,7 +302,7 @@ class WorkoutSessionServiceTest {
         "file", "test.jpg", "image/jpeg", imageBytes
     );
 
-    WorkoutMediaRequestDto dto = WorkoutMediaRequestDto.builder()
+    WorkoutImageRequestDto dto = WorkoutImageRequestDto.builder()
         .sessionId(10000L)
         .mediaFiles(List.of(mockFile))
         .build();
@@ -355,7 +355,7 @@ class WorkoutSessionServiceTest {
     MockMultipartFile mockFile = new MockMultipartFile(
         "file", "test.jpg", "image/jpeg", imageBytes);
 
-    WorkoutMediaRequestDto dto = WorkoutMediaRequestDto.builder()
+    WorkoutImageRequestDto dto = WorkoutImageRequestDto.builder()
         .sessionId(10000L)
         .mediaFiles(List.of(mockFile))
         .build();
@@ -397,7 +397,7 @@ class WorkoutSessionServiceTest {
         "file", "test.txt", "text/plain", "test text content" .getBytes()
     );
 
-    WorkoutMediaRequestDto dto = WorkoutMediaRequestDto.builder()
+    WorkoutImageRequestDto dto = WorkoutImageRequestDto.builder()
         .sessionId(10000L)
         .mediaFiles(List.of(mockFile))
         .build();

--- a/src/test/java/com/project/trainingdiary/service/WorkoutSessionServiceTest.java
+++ b/src/test/java/com/project/trainingdiary/service/WorkoutSessionServiceTest.java
@@ -304,7 +304,7 @@ class WorkoutSessionServiceTest {
 
     WorkoutImageRequestDto dto = WorkoutImageRequestDto.builder()
         .sessionId(10000L)
-        .mediaFiles(List.of(mockFile))
+        .images(List.of(mockFile))
         .build();
 
     workoutSessionService.uploadWorkoutMedia(dto);
@@ -357,7 +357,7 @@ class WorkoutSessionServiceTest {
 
     WorkoutImageRequestDto dto = WorkoutImageRequestDto.builder()
         .sessionId(10000L)
-        .mediaFiles(List.of(mockFile))
+        .images(List.of(mockFile))
         .build();
 
     assertThrows(MediaCountExceededException.class,
@@ -399,7 +399,7 @@ class WorkoutSessionServiceTest {
 
     WorkoutImageRequestDto dto = WorkoutImageRequestDto.builder()
         .sessionId(10000L)
-        .mediaFiles(List.of(mockFile))
+        .images(List.of(mockFile))
         .build();
 
     assertThrows(InvalidFileTypeException.class,


### PR DESCRIPTION
### 변경사항
**AS-IS**
운동 기록에 글 내용만 작성이 가능함


**TO-BE**
운동 일지에 이미지(자세 사진) 업로드 가능
- dto를 받을 때는 `@RequestBody` 주로 사용하고 file을 받기 위해서는 `@RequestParam`을 사용하지만 
sessionId와 file 받기위해 `@RequestPart` 사용
- 이미지는 10개까지 업로드 가능 
    - 한번에 11개 이상의 이미지를 업로드하거나 이미 10개의 이미지가 존재할 때 추가 업로드 불가
    - `MediaCountExceededException` 발생
- jpeg와 png 확장자를 가진 이미지만 업로드 가능
    - 그 외 다른 확장자 파일 업로드 불가
    - `InvalidFileTypeException` 발생
- 썸네일 생성
    -  `imgscalr` 이용해 높이, 너비 150 픽셀의 썸네일 이미지 생성
- 원본 이미지와 썸네일 이미지 업로드
    - 원본 이미지 : 랜덤 UUID로 Key값 설정(이미지 이름)
    - 썸네일 이미지 : "thumb_" + 원본 이미지 이름
- s3에 버킷 정책 설정으로 objectUrl 통해 업로드 이미지 확인 가능
- `uploadWorkoutImage` 메소드의 리턴 값을 `WorkoutImageResponseDto`로 수정해 
업로드한 이미지에 대한 url을 반환값으로 받을 수 있음


### 테스트
- 이미지 업로드 성공 테스트
- 이미지 업로드 실패 테스트
    - 운동 일지를 찾을 수 없을 때
    - 파일 타입이 맞지 않을 때
    - 이미지의 총 개수가 10개를 초과할 때