### PR TITLE
응답에 공통 필드를 사용하지 않음

### DIFF
--- a/src/main/java/com/project/trainingdiary/dto/response/CustomResponse.java
+++ b/src/main/java/com/project/trainingdiary/dto/response/CustomResponse.java
@@ -9,7 +9,10 @@ import org.springframework.http.ResponseEntity;
 
 /**
  * Response 공통화. 성공의 경우 SuccessMessage를 정의 후 사용해주세요. 실패의 경우 GlobalException을 활용해주세요.
+ *
+ * @deprecated 이 클래스 대신 ResponseEntity를 사용하세요.
  */
+@Deprecated
 public class CustomResponse<T> extends ResponseEntity<Map<String, Object>> {
 
   private static final String STATUS_CODE = "statusCode";

--- a/src/main/java/com/project/trainingdiary/exception/ErrorResponse.java
+++ b/src/main/java/com/project/trainingdiary/exception/ErrorResponse.java
@@ -1,0 +1,14 @@
+package com.project.trainingdiary.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class ErrorResponse {
+
+  private int errorCode;
+  private String message;
+}

--- a/src/main/java/com/project/trainingdiary/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/project/trainingdiary/handler/GlobalExceptionHandler.java
@@ -1,11 +1,12 @@
 package com.project.trainingdiary.handler;
 
-import com.project.trainingdiary.dto.response.CommonResponse;
+import com.project.trainingdiary.exception.ErrorResponse;
 import com.project.trainingdiary.exception.GlobalException;
 import jakarta.servlet.http.HttpServletRequest;
 import java.nio.file.AccessDeniedException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -14,24 +15,27 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 
   @ExceptionHandler(GlobalException.class)
-  public CommonResponse<?> handler(GlobalException e, HttpServletRequest request) {
+  public ResponseEntity<ErrorResponse> handler(GlobalException e, HttpServletRequest request) {
 
     log.error(
         "GlobalException, {}, {}, {}",
         e.getHttpStatus(), e.getMessage(), request.getRequestURI()
     );
 
-    return new CommonResponse<>(e.getHttpStatus(), e.getMessage());
+    ErrorResponse response = new ErrorResponse(e.getHttpStatus().value(), e.getMessage());
+    return new ResponseEntity<>(response, e.getHttpStatus());
   }
 
   @ExceptionHandler(AccessDeniedException.class)
-  public CommonResponse<?> handleAccessDeniedException(AccessDeniedException e,
+  public ResponseEntity<ErrorResponse> handleAccessDeniedException(AccessDeniedException e,
       HttpServletRequest request) {
+
     log.error(
         "AccessDeniedException, {}, {}, {}",
         HttpStatus.FORBIDDEN, e.getMessage(), request.getRequestURI()
     );
 
-    return new CommonResponse<>(HttpStatus.FORBIDDEN, "접근이 없습니다.");
+    ErrorResponse response = new ErrorResponse(HttpStatus.FORBIDDEN.value(), "접근 권한이 없습니다.");
+    return new ResponseEntity<>(response, HttpStatus.FORBIDDEN);
   }
 }

--- a/src/main/java/com/project/trainingdiary/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/project/trainingdiary/handler/GlobalExceptionHandler.java
@@ -4,15 +4,10 @@ import com.project.trainingdiary.exception.ErrorResponse;
 import com.project.trainingdiary.exception.GlobalException;
 import jakarta.servlet.http.HttpServletRequest;
 import java.nio.file.AccessDeniedException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
-import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -21,6 +16,12 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+  /**
+   * 프로젝트에서 생성한 예외를 처리합니다.
+   *
+   * @param e GlobalException
+   * @return ResponseEntity<ErrorResponse> - 전역 예외 응답
+   */
   @ExceptionHandler(GlobalException.class)
   public ResponseEntity<ErrorResponse> handler(GlobalException e, HttpServletRequest request) {
 
@@ -33,6 +34,12 @@ public class GlobalExceptionHandler {
     return new ResponseEntity<>(response, e.getHttpStatus());
   }
 
+  /**
+   * 필드 유효성 검사 예외를 처리합니다.
+   *
+   * @param e MethodArgumentNotValidException
+   * @return ResponseEntity<ErrorResponse> - 필드 유효성 검사 오류 응답
+   */
   @ExceptionHandler(AccessDeniedException.class)
   public ResponseEntity<ErrorResponse> handleAccessDeniedException(AccessDeniedException e,
       HttpServletRequest request) {
@@ -49,47 +56,38 @@ public class GlobalExceptionHandler {
   /**
    * 유효성 검사 예외를 처리합니다.
    *
-   * @param ex MethodArgumentNotValidException
-   * @return CustomResponse<Map < String, List < String>>> - 유효성 검사 오류 응답
+   * @param e MethodArgumentNotValidException
+   * @return ResponseEntity<ErrorResponse> - 유효성 검사 오류 응답
    */
   @ExceptionHandler(MethodArgumentNotValidException.class)
-  public ResponseEntity<Map<String, List<String>>> handleValidationExceptions(
-      MethodArgumentNotValidException ex) {
-    List<String> errors = ex.getBindingResult()
-        .getFieldErrors()
-        .stream()
-        .map(FieldError::getDefaultMessage)
-        .toList();
+  public ResponseEntity<ErrorResponse> handleValidationExceptions(
+      MethodArgumentNotValidException e, HttpServletRequest request) {
 
-    log.error("Validation exception: ", ex);
-    return new ResponseEntity<>(getErrorsMap(errors), new HttpHeaders(), HttpStatus.BAD_REQUEST);
+    log.error(
+        "MethodArgumentNotValidException, {}, {}, {}",
+        HttpStatus.BAD_REQUEST, e.getMessage(), request.getRequestURI()
+    );
+
+    ErrorResponse response = new ErrorResponse(HttpStatus.BAD_REQUEST.value(), e.getMessage());
+    return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
   }
 
   /**
    * JSON 형식 오류 예외를 처리합니다.
    *
-   * @param ex HttpMessageNotReadableException
-   * @return CustomResponse<Map < String, List < String>>> - 잘못된 JSON 요청 오류 응답
+   * @param e HttpMessageNotReadableException
+   * @return ResponseEntity<ErrorResponse> - 잘못된 JSON 요청 오류 응답
    */
   @ExceptionHandler(HttpMessageNotReadableException.class)
-  public ResponseEntity<Map<String, List<String>>> handleHttpMessageNotReadableException(
-      HttpMessageNotReadableException ex) {
-    List<String> errors = List.of("Malformed JSON request");
+  public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(
+      HttpMessageNotReadableException e, HttpServletRequest request) {
 
-    log.error("Malformed JSON request: ", ex);
-    return new ResponseEntity<>(getErrorsMap(errors), new HttpHeaders(), HttpStatus.BAD_REQUEST);
-  }
+    log.error(
+        "HttpMessageNotReadableException, {}, {}, {}",
+        HttpStatus.BAD_REQUEST, e.getMessage(), request.getRequestURI()
+    );
 
-
-  /**
-   * 오류 목록을 맵 형식으로 변환합니다.
-   *
-   * @param errors 오류 목록
-   * @return Map<String, List < String>> - 오류 맵
-   */
-  private Map<String, List<String>> getErrorsMap(List<String> errors) {
-    Map<String, List<String>> errorResponse = new HashMap<>();
-    errorResponse.put("errors", errors);
-    return errorResponse;
+    ErrorResponse response = new ErrorResponse(HttpStatus.BAD_REQUEST.value(), e.getMessage());
+    return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
   }
 }


### PR DESCRIPTION
### 변경사항

<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요 -->
**AS-IS**
- CustomResponse를 통해 statusCode, message, data 부분을 공통화함

**TO-BE**
- CustomResponse에 deprecated 표시
- CustomResponse 대신 ResponseEntity를 직접 사용하기로 함
- ErrorResponse를 별도로 만들어 에러 응답 시 사용
- API 사용 예
```java
@GetMapping("/sample/success")
public ResponseEntity<ExampleResponseDto> sampleSuccess() {
  ExampleResponseDto dto = new ExampleResponseDto("sample", 30);
  return ResponseEntity.ok(dto);
}
```