### PR TITLE
트레이너의 일정 등록

### DIFF
--- a/src/main/java/com/project/trainingdiary/controller/ScheduleController.java
+++ b/src/main/java/com/project/trainingdiary/controller/ScheduleController.java
@@ -4,8 +4,10 @@ import com.project.trainingdiary.dto.request.AcceptScheduleRequestDto;
 import com.project.trainingdiary.dto.request.ApplyScheduleRequestDto;
 import com.project.trainingdiary.dto.request.CloseScheduleRequestDto;
 import com.project.trainingdiary.dto.request.OpenScheduleRequestDto;
+import com.project.trainingdiary.dto.request.RegisterScheduleRequestDto;
 import com.project.trainingdiary.dto.request.RejectScheduleRequestDto;
 import com.project.trainingdiary.dto.response.CommonResponse;
+import com.project.trainingdiary.dto.response.RegisterScheduleResponseDto;
 import com.project.trainingdiary.dto.response.RejectScheduleResponseDto;
 import com.project.trainingdiary.model.SuccessMessage;
 import com.project.trainingdiary.service.ScheduleService;
@@ -73,6 +75,14 @@ public class ScheduleController {
       @RequestBody @Valid RejectScheduleRequestDto dto
   ) {
     RejectScheduleResponseDto response = scheduleService.rejectSchedule(dto);
+    return ResponseEntity.ok(response);
+  }
+
+  @PostMapping("/trainers/register")
+  public ResponseEntity<RegisterScheduleResponseDto> rejectSchedule(
+      @RequestBody @Valid RegisterScheduleRequestDto dto
+  ) {
+    RegisterScheduleResponseDto response = scheduleService.registerSchedule(dto);
     return ResponseEntity.ok(response);
   }
 }

--- a/src/main/java/com/project/trainingdiary/dto/request/RegisterScheduleRequestDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/request/RegisterScheduleRequestDto.java
@@ -1,0 +1,24 @@
+package com.project.trainingdiary.dto.request;
+
+import com.project.trainingdiary.model.ScheduleDateTimes;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class RegisterScheduleRequestDto {
+
+  @NotNull(message = "traineeId를 입력해주세요")
+  private Long traineeId;
+
+  @NotNull(message = "dateTimes를 입력해주세요")
+  private List<ScheduleDateTimes> dateTimes;
+}

--- a/src/main/java/com/project/trainingdiary/dto/response/RegisterScheduleResponseDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/response/RegisterScheduleResponseDto.java
@@ -1,0 +1,14 @@
+package com.project.trainingdiary.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class RegisterScheduleResponseDto {
+
+  private int reservedSession;
+  private int remainSession;
+}

--- a/src/main/java/com/project/trainingdiary/entity/PtContractEntity.java
+++ b/src/main/java/com/project/trainingdiary/entity/PtContractEntity.java
@@ -44,6 +44,10 @@ public class PtContractEntity extends BaseEntity {
   @JoinColumn(name = "trainee_id")
   private TraineeEntity trainee;
 
+  public int getRemainSession() {
+    return this.totalSession - this.usedSession;
+  }
+
   public void addSession(int addition) {
     this.totalSession += addition;
     this.totalSessionUpdatedAt = LocalDateTime.now();

--- a/src/main/java/com/project/trainingdiary/exception/impl/PtContractNotEnoughSession.java
+++ b/src/main/java/com/project/trainingdiary/exception/impl/PtContractNotEnoughSession.java
@@ -1,0 +1,11 @@
+package com.project.trainingdiary.exception.impl;
+
+import com.project.trainingdiary.exception.GlobalException;
+import org.springframework.http.HttpStatus;
+
+public class PtContractNotEnoughSession extends GlobalException {
+
+  public PtContractNotEnoughSession() {
+    super(HttpStatus.BAD_REQUEST, "PT 횟수가 부족합니다.");
+  }
+}

--- a/src/main/java/com/project/trainingdiary/service/ScheduleService.java
+++ b/src/main/java/com/project/trainingdiary/service/ScheduleService.java
@@ -215,7 +215,6 @@ public class ScheduleService {
    */
   @Transactional
   public RegisterScheduleResponseDto registerSchedule(RegisterScheduleRequestDto dto) {
-    System.out.println("dto = " + dto);
     TrainerEntity trainer = getTrainer();
     PtContractEntity ptContract = getPtContract(trainer.getId(), dto.getTraineeId());
 


### PR DESCRIPTION
### 변경사항

<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요 -->
**AS-IS**
- 트레이너의 일정 등록 기능 필요 

**TO-BE**
- 트레이너의 일정 등록 기능 추가 (트레이니의 신청과정 없이 직접 트레이너가 PT 시간을 등록하는 기능)

### 테스트

<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 

- [x] 테스트 코드
  - 일정 등록 - 성공(OPEN된 일정이 없는 경우)
  - 일정 등록 - 성공(이미 OPEN된 일정이 있는 경우라도 성공)
  - 일정 등록 - 실패(OPEN 상태가 아닌 일정이 이미 있는 경우)
  - 일정 등록 - 실패(PT 계약이 없는 경우)
  - 일정 등록 - 실패(PT 횟수가 부족한 경우)
- [x] API 테스트

- 호출 예시
POST api/schedules/trainers/register
```
{
  "traineeId": "1",
  "dateTimes": [
    {
      "startTimes": [
        "14:00"
      ],
      "startDate": "2024-08-01"
    },
    {
      "startTimes": [
        "14:00"
      ],
      "startDate": "2024-08-03"
    },
    {
      "startTimes": [
        "19:00"
      ],
      "startDate": "2024-08-05"
    }
  ]
}
```

Resolves #36 