### PR TITLE
PT 계약 관련 API 수정

### DIFF
--- a/src/main/java/com/project/trainingdiary/controller/PtContractController.java
+++ b/src/main/java/com/project/trainingdiary/controller/PtContractController.java
@@ -1,24 +1,31 @@
 package com.project.trainingdiary.controller;
 
-import com.project.trainingdiary.dto.request.AddPtContractSessionRequestDto;
 import com.project.trainingdiary.dto.request.CreatePtContractRequestDto;
 import com.project.trainingdiary.dto.request.TerminatePtContractRequestDto;
+import com.project.trainingdiary.dto.response.CreatePtContractResponseDto;
 import com.project.trainingdiary.dto.response.PtContractResponseDto;
 import com.project.trainingdiary.model.PtContractSort;
 import com.project.trainingdiary.service.PtContractService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "6 - PT 계약")
 @RestController
 @AllArgsConstructor
 @RequestMapping("api/pt-contracts")
@@ -26,39 +33,48 @@ public class PtContractController {
 
   private final PtContractService ptContractService;
 
+  @Operation(
+      summary = "PT 계약을 생성",
+      description = "트레이너가 트레이니와 PT 계약을 생성함"
+  )
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "성공"),
+      @ApiResponse(responseCode = "409", description = "트레이너와 트레이니가 이미 계약이 있습니다.", content = @Content)
+  })
+  @PreAuthorize("hasRole('TRAINER')")
   @PostMapping
-  public ResponseEntity<Void> createPtContract(
+  public ResponseEntity<CreatePtContractResponseDto> createPtContract(
       @RequestBody @Valid CreatePtContractRequestDto dto
   ) {
-    ptContractService.createPtContract(dto);
-    return ResponseEntity.ok().build();
+    return ResponseEntity.ok(ptContractService.createPtContract(dto));
   }
 
+  @Operation(
+      summary = "PT 계약 목록을 조회",
+      description = "자신의 PT 계약 목록을 조회함"
+  )
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "성공")
+  })
   @GetMapping
   public ResponseEntity<Page<PtContractResponseDto>> getPtContractList(
-      Pageable pageable,
+      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "20") int size,
       @RequestParam PtContractSort sortBy
   ) {
-    Page<PtContractResponseDto> ptContracts = ptContractService.getPtContractList(pageable, sortBy);
-    return ResponseEntity.ok(ptContracts);
+    Pageable pageable = PageRequest.of(page, size);
+    return ResponseEntity.ok(ptContractService.getPtContractList(pageable, sortBy));
   }
 
-  @GetMapping("/{id}")
-  public ResponseEntity<PtContractResponseDto> getPtContract(
-      @PathVariable long id
-  ) {
-    PtContractResponseDto ptContract = ptContractService.getPtContract(id);
-    return ResponseEntity.ok(ptContract);
-  }
-
-  @PostMapping("/add-session")
-  public ResponseEntity<Void> addPtContractSession(
-      @RequestBody @Valid AddPtContractSessionRequestDto dto
-  ) {
-    ptContractService.addPtContractSession(dto);
-    return ResponseEntity.ok().build();
-  }
-
+  @Operation(
+      summary = "PT 계약 종료",
+      description = "트레이너가 PT 계약을 종료함"
+  )
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "성공"),
+      @ApiResponse(responseCode = "404", description = "계약이 없습니다.")
+  })
+  @PreAuthorize("hasRole('TRAINER')")
   @PostMapping("/terminate")
   public ResponseEntity<Void> terminatePtContract(
       @RequestBody @Valid TerminatePtContractRequestDto dto

--- a/src/main/java/com/project/trainingdiary/controller/PtContractController.java
+++ b/src/main/java/com/project/trainingdiary/controller/PtContractController.java
@@ -3,7 +3,6 @@ package com.project.trainingdiary.controller;
 import com.project.trainingdiary.dto.request.AddPtContractSessionRequestDto;
 import com.project.trainingdiary.dto.request.CreatePtContractRequestDto;
 import com.project.trainingdiary.dto.request.TerminatePtContractRequestDto;
-import com.project.trainingdiary.dto.response.CommonResponse;
 import com.project.trainingdiary.dto.response.PtContractResponseDto;
 import com.project.trainingdiary.model.PtContractSort;
 import com.project.trainingdiary.service.PtContractService;
@@ -11,6 +10,7 @@ import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -27,43 +27,43 @@ public class PtContractController {
   private final PtContractService ptContractService;
 
   @PostMapping
-  public CommonResponse<?> createPtContract(
+  public ResponseEntity<Void> createPtContract(
       @RequestBody @Valid CreatePtContractRequestDto dto
   ) {
     ptContractService.createPtContract(dto);
-    return CommonResponse.created();
+    return ResponseEntity.ok().build();
   }
 
   @GetMapping
-  public CommonResponse<?> getPtContractList(
+  public ResponseEntity<Page<PtContractResponseDto>> getPtContractList(
       Pageable pageable,
       @RequestParam PtContractSort sortBy
   ) {
     Page<PtContractResponseDto> ptContracts = ptContractService.getPtContractList(pageable, sortBy);
-    return CommonResponse.success(ptContracts);
+    return ResponseEntity.ok(ptContracts);
   }
 
   @GetMapping("/{id}")
-  public CommonResponse<?> getPtContract(
+  public ResponseEntity<PtContractResponseDto> getPtContract(
       @PathVariable long id
   ) {
     PtContractResponseDto ptContract = ptContractService.getPtContract(id);
-    return CommonResponse.success(ptContract);
+    return ResponseEntity.ok(ptContract);
   }
 
   @PostMapping("/add-session")
-  public CommonResponse<?> addPtContractSession(
+  public ResponseEntity<Void> addPtContractSession(
       @RequestBody @Valid AddPtContractSessionRequestDto dto
   ) {
     ptContractService.addPtContractSession(dto);
-    return CommonResponse.success();
+    return ResponseEntity.ok().build();
   }
 
   @PostMapping("/terminate")
-  public CommonResponse<?> terminatePtContract(
+  public ResponseEntity<Void> terminatePtContract(
       @RequestBody @Valid TerminatePtContractRequestDto dto
   ) {
     ptContractService.terminatePtContract(dto);
-    return CommonResponse.success();
+    return ResponseEntity.ok().build();
   }
 }

--- a/src/main/java/com/project/trainingdiary/dto/request/CreatePtContractRequestDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/request/CreatePtContractRequestDto.java
@@ -1,7 +1,7 @@
 package com.project.trainingdiary.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.PositiveOrZero;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -9,9 +9,7 @@ import lombok.Setter;
 @Setter
 public class CreatePtContractRequestDto {
 
-  @NotNull(message = "traineeEmail를 입력하세요")
+  @NotNull(message = "traineeEmail을 입력하세요")
+  @Schema(example = "hello@example.com")
   private String traineeEmail;
-
-  @PositiveOrZero(message = "sessionCount는 0 이상이어야 합니다")
-  private int sessionCount;
 }

--- a/src/main/java/com/project/trainingdiary/dto/request/TerminatePtContractRequestDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/request/TerminatePtContractRequestDto.java
@@ -1,5 +1,6 @@
 package com.project.trainingdiary.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
@@ -9,5 +10,6 @@ import lombok.Setter;
 public class TerminatePtContractRequestDto {
 
   @NotNull(message = "PT 계약 id를 입력해주세요")
+  @Schema(example = "1")
   private Long ptContractId;
 }

--- a/src/main/java/com/project/trainingdiary/dto/response/CreatePtContractResponseDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/response/CreatePtContractResponseDto.java
@@ -1,0 +1,15 @@
+package com.project.trainingdiary.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class CreatePtContractResponseDto {
+
+  @Schema(example = "1")
+  private Long ptContractId;
+}

--- a/src/main/java/com/project/trainingdiary/exception/impl/PtContractAlreadyExistException.java
+++ b/src/main/java/com/project/trainingdiary/exception/impl/PtContractAlreadyExistException.java
@@ -6,6 +6,6 @@ import org.springframework.http.HttpStatus;
 public class PtContractAlreadyExistException extends GlobalException {
 
   public PtContractAlreadyExistException() {
-    super(HttpStatus.BAD_REQUEST, "트레이너와 트레이니가 이미 계약이 있습니다.");
+    super(HttpStatus.CONFLICT, "트레이너와 트레이니가 이미 계약이 있습니다.");
   }
 }

--- a/src/main/resources/application-sample.yml
+++ b/src/main/resources/application-sample.yml
@@ -49,3 +49,7 @@ spring:
 
 server:
   forward-headers-strategy: framework # Swagger에서 https 요청이 나가도록 하기 위함
+
+springdoc:
+  swagger-ui:
+    tagsSorter: alpha


### PR DESCRIPTION
### 변경사항

<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요 -->
**AS-IS**
- PT 계약 관련 API 수정 필요

**TO-BE**
- CommonResponse 대신 ResponseEntity 사용 (응답 공통화 부분 제거)
- 현재 기획에서 사용되지 않는 API 제거(특정 PT 계약 조회 API, 세션 추가 API)
- 계약 생성 시 응답 객체 추가
- PT 계약 예외 코드 수정(기존의 400보다 409 CONFLICT가 더 적절하다고 판단)
- Pageable 대신 page, size 를 별도로 받음
  - Pageable을 직접 받으면, page, size, sort 까지 받게됨. 하지만 sort는 자체 정의한 enum을 사용하기 때문에 제외되어야 함

### 테스트

<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 

- [x] API 테스트
GET api/pt-contracts
POST api/pt-contracts
POST api/pt-contracts/terminate

Resolves #57 