### PR TITLE
트레이니 정보 수정 시 남은 세션 횟수 수정

### DIFF
--- a/src/main/java/com/project/trainingdiary/controller/TrainerController.java
+++ b/src/main/java/com/project/trainingdiary/controller/TrainerController.java
@@ -48,7 +48,7 @@ public class TrainerController {
       @ApiResponse(responseCode = "200", description = "수정 성공"),
   })
   @PreAuthorize("hasRole('TRAINER')")
-  @PutMapping("/trainees/")
+  @PutMapping("/trainees")
   public ResponseEntity<EditTraineeInfoResponseDto> editTraineeInfo(
       @RequestBody @Valid EditTraineeInfoRequestDto dto
   ) {
@@ -61,7 +61,7 @@ public class TrainerController {
       @ApiResponse(responseCode = "200", description = "추가 성공"),
   })
   @PreAuthorize("hasRole('TRAINER')")
-  @PostMapping("/trainees/")
+  @PostMapping("/trainees")
   public ResponseEntity<AddInBodyInfoResponseDto> addInBodyRecord(
       @RequestBody @Valid AddInBodyInfoRequestDto dto
   ) {

--- a/src/main/java/com/project/trainingdiary/dto/request/EditTraineeInfoRequestDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/request/EditTraineeInfoRequestDto.java
@@ -31,8 +31,8 @@ public class EditTraineeInfoRequestDto {
   private double height;
 
   @Schema(example = "5")
-  @Positive(message = "remainingSessions 값은 양수이어야 합니다.")
-  private int remainingSessions;
+  @Positive(message = "remainingSession 값은 양수이어야 합니다.")
+  private int remainingSession;
 
   @Schema(example = "TARGET_WEIGHT", allowableValues = {"TARGET_WEIGHT",
       "TARGET_BODY_FAT_PERCENTAGE", "TARGET_SKELETAL_MUSCLE_MASS"})

--- a/src/main/java/com/project/trainingdiary/dto/response/EditTraineeInfoResponseDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/response/EditTraineeInfoResponseDto.java
@@ -15,7 +15,7 @@ public class EditTraineeInfoResponseDto {
   private LocalDate birthDate;
   private GenderType gender;
   private double height;
-  private int remainingSessions;
+  private int remainingSession;
   private TargetType targetType;
   private double targetValue;
   private String targetReward;

--- a/src/main/java/com/project/trainingdiary/dto/response/EditTraineeInfoResponseDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/response/EditTraineeInfoResponseDto.java
@@ -1,5 +1,6 @@
 package com.project.trainingdiary.dto.response;
 
+import com.project.trainingdiary.entity.PtContractEntity;
 import com.project.trainingdiary.entity.TraineeEntity;
 import com.project.trainingdiary.model.GenderType;
 import com.project.trainingdiary.model.TargetType;
@@ -20,7 +21,8 @@ public class EditTraineeInfoResponseDto {
   private double targetValue;
   private String targetReward;
 
-  public static EditTraineeInfoResponseDto fromEntity(TraineeEntity trainee) {
+  public static EditTraineeInfoResponseDto fromEntity(TraineeEntity trainee,
+      PtContractEntity ptContract) {
     return EditTraineeInfoResponseDto.builder()
         .traineeId(trainee.getId())
         .birthDate(trainee.getBirthDate())
@@ -29,6 +31,7 @@ public class EditTraineeInfoResponseDto {
         .targetType(trainee.getTargetType())
         .targetValue(trainee.getTargetValue())
         .targetReward(trainee.getTargetReward())
+        .remainingSession(ptContract.getRemainingSession())
         .build();
   }
 }

--- a/src/main/java/com/project/trainingdiary/dto/response/PtContractResponseDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/response/PtContractResponseDto.java
@@ -12,8 +12,6 @@ public class PtContractResponseDto {
 
   private Long ptContractId;
   private LocalDateTime totalSessionUpdatedAt;
-  private int totalSession;
-  private int usedSession;
   private int remainingSession;
   private Long trainerId;
   private String trainerName;

--- a/src/main/java/com/project/trainingdiary/dto/response/PtContractResponseDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/response/PtContractResponseDto.java
@@ -14,7 +14,7 @@ public class PtContractResponseDto {
   private LocalDateTime totalSessionUpdatedAt;
   private int totalSession;
   private int usedSession;
-  private int remainSession;
+  private int remainingSession;
   private Long trainerId;
   private String trainerName;
   private Long traineeId;

--- a/src/main/java/com/project/trainingdiary/dto/response/RegisterScheduleResponseDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/response/RegisterScheduleResponseDto.java
@@ -10,5 +10,5 @@ import lombok.Setter;
 public class RegisterScheduleResponseDto {
 
   private int reservedSession;
-  private int remainSession;
+  private int remainingSession;
 }

--- a/src/main/java/com/project/trainingdiary/dto/response/TraineeInfoResponseDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/response/TraineeInfoResponseDto.java
@@ -25,7 +25,7 @@ public class TraineeInfoResponseDto {
   private GenderType gender;
   private double height;
   private LocalDate birthDate;
-  private int remainingSessions;
+  private int remainingSession;
 
   private List<WeightHistoryDto> weightHistory;
   private List<BodyFatHistoryDto> bodyFatHistory;
@@ -34,7 +34,7 @@ public class TraineeInfoResponseDto {
   private double targetValue;
   private String targetReward;
 
-  public static TraineeInfoResponseDto fromEntity(TraineeEntity trainee, int remainingSessions) {
+  public static TraineeInfoResponseDto fromEntity(TraineeEntity trainee, int remainingSession) {
     return TraineeInfoResponseDto.builder()
         .traineeId(trainee.getId())
         .name(trainee.getName())
@@ -42,7 +42,7 @@ public class TraineeInfoResponseDto {
         .birthDate(trainee.getBirthDate())
         .gender(trainee.getGender())
         .height(trainee.getHeight())
-        .remainingSessions(remainingSessions)
+        .remainingSession(remainingSession)
         .weightHistory(trainee.getInBodyRecords().stream()
             .map(WeightHistoryDto::fromEntity)
             .collect(Collectors.toList()))

--- a/src/main/java/com/project/trainingdiary/entity/PtContractEntity.java
+++ b/src/main/java/com/project/trainingdiary/entity/PtContractEntity.java
@@ -84,9 +84,7 @@ public class PtContractEntity extends BaseEntity {
         .trainerName(trainer.getName())
         .traineeId(trainee.getId())
         .traineeName(trainee.getName())
-        .usedSession(usedSession)
-        .totalSession(totalSession)
-        .remainingSession(totalSession - usedSession)
+        .remainingSession(getRemainingSession())
         .totalSessionUpdatedAt(totalSessionUpdatedAt)
         .build();
   }

--- a/src/main/java/com/project/trainingdiary/entity/PtContractEntity.java
+++ b/src/main/java/com/project/trainingdiary/entity/PtContractEntity.java
@@ -59,7 +59,7 @@ public class PtContractEntity extends BaseEntity {
     this.usedSession += 1;
   }
 
-  public void unuseSession() {
+  public void restoreSession() {
     this.usedSession -= 1;
   }
 

--- a/src/main/java/com/project/trainingdiary/entity/PtContractEntity.java
+++ b/src/main/java/com/project/trainingdiary/entity/PtContractEntity.java
@@ -46,7 +46,7 @@ public class PtContractEntity extends BaseEntity {
   @JoinColumn(name = "trainee_id")
   private TraineeEntity trainee;
 
-  public int getRemainSession() {
+  public int getRemainingSession() {
     return this.totalSession - this.usedSession;
   }
 
@@ -86,7 +86,7 @@ public class PtContractEntity extends BaseEntity {
         .traineeName(trainee.getName())
         .usedSession(usedSession)
         .totalSession(totalSession)
-        .remainSession(totalSession - usedSession)
+        .remainingSession(totalSession - usedSession)
         .totalSessionUpdatedAt(totalSessionUpdatedAt)
         .build();
   }

--- a/src/main/java/com/project/trainingdiary/service/ScheduleOpenCloseService.java
+++ b/src/main/java/com/project/trainingdiary/service/ScheduleOpenCloseService.java
@@ -98,7 +98,7 @@ public class ScheduleOpenCloseService {
     existingStartTimes.retainAll(requestedStartTimes); // 요청한 것 중 존재하는 시간만 남김
 
     // 남은 PT 횟수가 부족하면 에러를 냄
-    if (requestedStartTimes.size() > ptContract.getRemainSession()) {
+    if (requestedStartTimes.size() > ptContract.getRemainingSession()) {
       throw new PtContractNotEnoughSession();
     }
 
@@ -118,7 +118,7 @@ public class ScheduleOpenCloseService {
 
     return new RegisterScheduleResponseDto(
         newSchedules.size() + existingSchedules.size(),
-        ptContract.getRemainSession()
+        ptContract.getRemainingSession()
     );
   }
 

--- a/src/main/java/com/project/trainingdiary/service/ScheduleTraineeService.java
+++ b/src/main/java/com/project/trainingdiary/service/ScheduleTraineeService.java
@@ -98,7 +98,7 @@ public class ScheduleTraineeService {
 
     // PtContract의 사용을 먼저 취소하고, schedule cancel을 해야함. cancel을 먼저하면 ptContract가 null로 변함
     PtContractEntity ptContract = schedule.getPtContract();
-    ptContract.unuseSession();
+    ptContract.restoreSession();
     ptContractRepository.save(ptContract);
 
     schedule.cancel();

--- a/src/main/java/com/project/trainingdiary/service/ScheduleTrainerService.java
+++ b/src/main/java/com/project/trainingdiary/service/ScheduleTrainerService.java
@@ -98,7 +98,7 @@ public class ScheduleTrainerService {
     schedule.rejectReserveApplied();
     scheduleRepository.save(schedule);
 
-    ptContract.unuseSession();
+    ptContract.restoreSession();
     ptContractRepository.save(ptContract);
 
     return new RejectScheduleResponseDto(schedule.getId(), schedule.getScheduleStatus());
@@ -123,7 +123,7 @@ public class ScheduleTrainerService {
 
     // PtContract의 사용을 먼저 취소하고, schedule cancel을 해야함. cancel을 먼저하면 ptContract가 null로 변함
     PtContractEntity ptContract = schedule.getPtContract();
-    ptContract.unuseSession();
+    ptContract.restoreSession();
     ptContractRepository.save(ptContract);
 
     schedule.cancel();

--- a/src/main/java/com/project/trainingdiary/service/TrainerService.java
+++ b/src/main/java/com/project/trainingdiary/service/TrainerService.java
@@ -82,12 +82,13 @@ public class TrainerService {
   public EditTraineeInfoResponseDto editTraineeInfo(EditTraineeInfoRequestDto dto) {
     TrainerEntity trainer = getAuthenticatedTrainer();
     TraineeEntity trainee = getTraineeById(dto.getTraineeId());
-
-    checkContract(trainer, trainee);
+    PtContractEntity ptContract = getPtContract(trainer, trainee);
 
     updateTraineeInfo(trainee, dto);
 
-    return EditTraineeInfoResponseDto.fromEntity(trainee);
+    updateRemainingSession(ptContract, dto);
+
+    return EditTraineeInfoResponseDto.fromEntity(trainee, ptContract);
   }
 
   /**
@@ -118,6 +119,11 @@ public class TrainerService {
         .orElseThrow(TrainerNotFoundException::new);
   }
 
+  private PtContractEntity getPtContract(TrainerEntity trainer, TraineeEntity trainee) {
+    return ptContractRepository.findByTrainerIdAndTraineeId(trainer.getId(), trainee.getId())
+        .orElseThrow(PtContractNotExistException::new);
+  }
+
   /**
    * 트레이너와 트레이니 간의 계약을 확인합니다.
    *
@@ -144,5 +150,11 @@ public class TrainerService {
     trainee.setTargetType(dto.getTargetType());
     trainee.setTargetValue(dto.getTargetValue());
     trainee.setTargetReward(dto.getTargetReward());
+  }
+
+  private void updateRemainingSession(PtContractEntity ptContract, EditTraineeInfoRequestDto dto) {
+    int remainingSession = dto.getRemainingSession();
+    int addition = remainingSession - ptContract.getRemainingSession();
+    ptContract.addSession(addition);
   }
 }

--- a/src/main/java/com/project/trainingdiary/service/TrainerService.java
+++ b/src/main/java/com/project/trainingdiary/service/TrainerService.java
@@ -40,19 +40,9 @@ public class TrainerService {
   public TraineeInfoResponseDto getTraineeInfo(Long id) {
     TrainerEntity trainer = getAuthenticatedTrainer();
     TraineeEntity trainee = getTraineeById(id);
+    PtContractEntity ptContract = getPtContract(trainer, trainee);
 
-    checkContract(trainer, trainee);
-
-    int totalSessions = ptContractRepository.findByTraineeId(trainee.getId()).stream()
-        .mapToInt(PtContractEntity::getTotalSession)
-        .sum();
-    int usedSessions = ptContractRepository.findByTraineeId(trainee.getId()).stream()
-        .mapToInt(PtContractEntity::getUsedSession)
-        .sum();
-
-    int remainingSession = totalSessions - usedSessions;
-
-    return TraineeInfoResponseDto.fromEntity(trainee, remainingSession);
+    return TraineeInfoResponseDto.fromEntity(trainee, ptContract.getRemainingSession());
   }
 
   /**

--- a/src/main/java/com/project/trainingdiary/service/TrainerService.java
+++ b/src/main/java/com/project/trainingdiary/service/TrainerService.java
@@ -50,9 +50,9 @@ public class TrainerService {
         .mapToInt(PtContractEntity::getUsedSession)
         .sum();
 
-    int remainingSessions = totalSessions - usedSessions;
+    int remainingSession = totalSessions - usedSessions;
 
-    return TraineeInfoResponseDto.fromEntity(trainee, remainingSessions);
+    return TraineeInfoResponseDto.fromEntity(trainee, remainingSession);
   }
 
   /**

--- a/src/test/java/com/project/trainingdiary/service/ScheduleOpenCloseServiceTest.java
+++ b/src/test/java/com/project/trainingdiary/service/ScheduleOpenCloseServiceTest.java
@@ -420,7 +420,7 @@ class ScheduleOpenCloseServiceTest {
     assertEquals(3, captorSchedule.getAllValues().get(0).size());
     assertEquals(0, captorSchedule.getAllValues().get(1).size());
     assertEquals(3, captorPtContract.getValue().getUsedSession());
-    assertEquals(7, response.getRemainSession());
+    assertEquals(7, response.getRemainingSession());
   }
 
   @Test
@@ -480,7 +480,7 @@ class ScheduleOpenCloseServiceTest {
     assertEquals(2, captorSchedule.getAllValues().get(0).size());
     assertEquals(1, captorSchedule.getAllValues().get(1).size());
     assertEquals(3, captorPtContract.getValue().getUsedSession());
-    assertEquals(7, response.getRemainSession());
+    assertEquals(7, response.getRemainingSession());
   }
 
   @Test

--- a/src/test/java/com/project/trainingdiary/service/TrainerServiceTest.java
+++ b/src/test/java/com/project/trainingdiary/service/TrainerServiceTest.java
@@ -134,8 +134,7 @@ public class TrainerServiceTest {
     when(authentication.getName()).thenReturn(trainerEmail);
     when(trainerRepository.findByEmail(trainerEmail)).thenReturn(Optional.of(trainer));
     when(traineeRepository.findById(traineeId)).thenReturn(Optional.of(trainee));
-    when(ptContractRepository.existsByTrainerIdAndTraineeId(trainerId, traineeId)).thenReturn(true);
-    when(ptContractRepository.findByTraineeId(trainee.getId())).thenReturn(Optional.of(contract));
+    when(ptContractRepository.findByTrainerIdAndTraineeId(trainerId, traineeId)).thenReturn(Optional.of(contract));
 
     // when
     TraineeInfoResponseDto responseDto = trainerService.getTraineeInfo(traineeId);
@@ -145,7 +144,7 @@ public class TrainerServiceTest {
     assertEquals(traineeId, responseDto.getTraineeId());
     verify(trainerRepository, times(1)).findByEmail(trainerEmail);
     verify(traineeRepository, times(1)).findById(traineeId);
-    verify(ptContractRepository, times(1)).existsByTrainerIdAndTraineeId(trainerId, traineeId);
+    verify(ptContractRepository, times(1)).findByTrainerIdAndTraineeId(trainerId, traineeId);
   }
 
   @Test
@@ -333,8 +332,8 @@ public class TrainerServiceTest {
     when(authentication.getName()).thenReturn(trainerEmail);
     when(trainerRepository.findByEmail(trainerEmail)).thenReturn(Optional.of(trainer));
     when(traineeRepository.findById(traineeId)).thenReturn(Optional.of(trainee));
-    when(ptContractRepository.existsByTrainerIdAndTraineeId(trainerId, traineeId)).thenReturn(
-        false);
+    when(ptContractRepository.findByTrainerIdAndTraineeId(trainerId, traineeId)).thenReturn(
+        Optional.empty());
 
     // when / then
     assertThrows(PtContractNotExistException.class, () -> trainerService.getTraineeInfo(traineeId));

--- a/src/test/java/com/project/trainingdiary/service/TrainerServiceTest.java
+++ b/src/test/java/com/project/trainingdiary/service/TrainerServiceTest.java
@@ -141,7 +141,7 @@ public class TrainerServiceTest {
     TraineeInfoResponseDto responseDto = trainerService.getTraineeInfo(traineeId);
 
     // then
-    assertEquals(5, responseDto.getRemainingSessions());
+    assertEquals(5, responseDto.getRemainingSession());
     assertEquals(traineeId, responseDto.getTraineeId());
     verify(trainerRepository, times(1)).findByEmail(trainerEmail);
     verify(traineeRepository, times(1)).findById(traineeId);

--- a/src/test/java/com/project/trainingdiary/service/TrainerServiceTest.java
+++ b/src/test/java/com/project/trainingdiary/service/TrainerServiceTest.java
@@ -190,11 +190,20 @@ public class TrainerServiceTest {
     dto.setTargetType(TargetType.TARGET_BODY_FAT_PERCENTAGE);
     dto.setTargetValue(70);
     dto.setTargetReward("Reward");
+    dto.setRemainingSession(20);
 
     when(authentication.getName()).thenReturn(trainerEmail);
     when(trainerRepository.findByEmail(trainerEmail)).thenReturn(Optional.of(trainer));
     when(traineeRepository.findById(traineeId)).thenReturn(Optional.of(trainee));
-    when(ptContractRepository.existsByTrainerIdAndTraineeId(trainerId, traineeId)).thenReturn(true);
+    when(ptContractRepository.findByTrainerIdAndTraineeId(trainerId, traineeId)).thenReturn(
+        Optional.of(
+            PtContractEntity.builder()
+                .trainer(trainer)
+                .trainee(trainee)
+                .totalSession(10)
+                .build()
+        )
+    );
 
     // when
     EditTraineeInfoResponseDto responseDto = trainerService.editTraineeInfo(dto);
@@ -206,10 +215,11 @@ public class TrainerServiceTest {
     assertEquals(dto.getTargetType(), responseDto.getTargetType());
     assertEquals(dto.getTargetValue(), responseDto.getTargetValue());
     assertEquals(dto.getTargetReward(), responseDto.getTargetReward());
+    assertEquals(dto.getRemainingSession(), responseDto.getRemainingSession());
 
     verify(trainerRepository, times(1)).findByEmail(trainerEmail);
     verify(traineeRepository, times(1)).findById(traineeId);
-    verify(ptContractRepository, times(1)).existsByTrainerIdAndTraineeId(trainerId, traineeId);
+    verify(ptContractRepository, times(1)).findByTrainerIdAndTraineeId(trainerId, traineeId);
   }
 
   @Test
@@ -377,8 +387,8 @@ public class TrainerServiceTest {
     when(authentication.getName()).thenReturn(trainerEmail);
     when(trainerRepository.findByEmail(trainerEmail)).thenReturn(Optional.of(trainer));
     when(traineeRepository.findById(traineeId)).thenReturn(Optional.of(trainee));
-    when(ptContractRepository.existsByTrainerIdAndTraineeId(trainerId, traineeId)).thenReturn(
-        false);
+    when(ptContractRepository.findByTrainerIdAndTraineeId(trainerId, traineeId)).thenReturn(
+        Optional.empty());
 
     // when / then
     assertThrows(PtContractNotExistException.class, () -> trainerService.editTraineeInfo(dto));

--- a/src/test/java/com/project/trainingdiary/service/TrainerServiceTest.java
+++ b/src/test/java/com/project/trainingdiary/service/TrainerServiceTest.java
@@ -134,7 +134,8 @@ public class TrainerServiceTest {
     when(authentication.getName()).thenReturn(trainerEmail);
     when(trainerRepository.findByEmail(trainerEmail)).thenReturn(Optional.of(trainer));
     when(traineeRepository.findById(traineeId)).thenReturn(Optional.of(trainee));
-    when(ptContractRepository.findByTrainerIdAndTraineeId(trainerId, traineeId)).thenReturn(Optional.of(contract));
+    when(ptContractRepository.findByTrainerIdAndTraineeId(trainerId, traineeId)).thenReturn(
+        Optional.of(contract));
 
     // when
     TraineeInfoResponseDto responseDto = trainerService.getTraineeInfo(traineeId);


### PR DESCRIPTION
### 변경사항

<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요 -->
**AS-IS**
- 트레이니 정보 수정 시 PT 잔여 횟수 수정 필요

**TO-BE**
- PT 계약을 통해 잔여 횟수가 수정되도록 함
- 여러 곳에서 사용되던 잔여 횟수의 변수명 통일
- 전체 횟수와 사용한 횟수는 클라이언트에서 사용하지 않는 것으로 확인했으므로 제외

### 테스트

<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 

- [x] 테스트 코드
  - 트레이니 정보 조회 및 트레이니 정보 수정 시 잔여횟수 관련 필드를 넣어서 동작하도록 수정
- [x] API 테스트
  - GET /api/trainers/trainees
  - PUT /api/trainers/trainees

Resolves #68 