### PR TITLE
트레이니 식단 추가 (이미지 및 텍스트 추가)

### DIFF
--- a/src/main/java/com/project/trainingdiary/controller/DietController.java
+++ b/src/main/java/com/project/trainingdiary/controller/DietController.java
@@ -1,0 +1,47 @@
+package com.project.trainingdiary.controller;
+
+import com.project.trainingdiary.dto.request.CreateDietRequestDto;
+import com.project.trainingdiary.dto.response.DietImageResponseDto;
+import com.project.trainingdiary.service.DietService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.io.IOException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@Tag(name = "7 - Diet API", description = "트레이니의 식단 관련 API")
+@RestController
+@RequestMapping("api/diets/")
+@RequiredArgsConstructor
+public class DietController {
+
+  private final DietService dietService;
+
+  @Operation(summary = "식단 생성", description = "트레이니가 이미지를 업로드하고 식단 내용을 추가하여 식단을 생성합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "성공"),
+  })
+  @PreAuthorize("hasRole('TRAINEE')")
+  @PostMapping
+  public ResponseEntity<DietImageResponseDto> createDiet(
+      @RequestPart("images") List<MultipartFile> images,
+      @RequestPart("content") String content
+  ) throws IOException {
+    CreateDietRequestDto dto = CreateDietRequestDto.builder()
+        .images(images)
+        .content(content)
+        .build();
+
+    DietImageResponseDto response = dietService.createDiet(dto);
+    return ResponseEntity.ok(response);
+  }
+}

--- a/src/main/java/com/project/trainingdiary/dto/request/CreateDietRequestDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/request/CreateDietRequestDto.java
@@ -1,0 +1,14 @@
+package com.project.trainingdiary.dto.request;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Builder
+public class CreateDietRequestDto {
+
+  private String content;
+  List<MultipartFile> images;
+}

--- a/src/main/java/com/project/trainingdiary/dto/request/SignUpRequestDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/request/SignUpRequestDto.java
@@ -4,6 +4,7 @@ import com.project.trainingdiary.model.UserRoleType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.Setter;
@@ -31,8 +32,8 @@ public class SignUpRequestDto {
   @NotBlank(message = "name은 필수 입력 값입니다.")
   private String name;
 
-  @Schema(example = "TRAINER", allowableValues = {"TRAINEE, TRAINER"})
-  @NotBlank(message = "role은 필수 입력 값입니다.")
+  @Schema(example = "TRAINER", allowableValues = {"TRAINEE", "TRAINER"})
+  @NotNull(message = "role은 필수 입력 값입니다.")
   private UserRoleType role;
 
 }

--- a/src/main/java/com/project/trainingdiary/dto/response/DietImageResponseDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/response/DietImageResponseDto.java
@@ -1,0 +1,16 @@
+package com.project.trainingdiary.dto.response;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@Builder
+public class DietImageResponseDto {
+  private List<String> originalUrl;
+  private List<String> thumbnailUrl;
+}

--- a/src/main/java/com/project/trainingdiary/dto/response/DietImageResponseDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/response/DietImageResponseDto.java
@@ -11,6 +11,7 @@ import lombok.Setter;
 @AllArgsConstructor
 @Builder
 public class DietImageResponseDto {
+
   private List<String> originalUrl;
   private List<String> thumbnailUrl;
 }

--- a/src/main/java/com/project/trainingdiary/entity/DietEntity.java
+++ b/src/main/java/com/project/trainingdiary/entity/DietEntity.java
@@ -1,0 +1,35 @@
+package com.project.trainingdiary.entity;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity(name = "diet")
+@Getter
+@Setter
+public class DietEntity extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = IDENTITY)
+  private Long id;
+
+  private String content;
+
+  @Column(length = 2000)
+  private String originalUrl;
+
+  @Column(length = 2000)
+  private String thumbnailUrl;
+
+  @ManyToOne(fetch = LAZY)
+  @JoinColumn(name = "trainee_id")
+  private TraineeEntity trainee;
+}

--- a/src/main/java/com/project/trainingdiary/repository/DietRepository.java
+++ b/src/main/java/com/project/trainingdiary/repository/DietRepository.java
@@ -1,0 +1,8 @@
+package com.project.trainingdiary.repository;
+
+import com.project.trainingdiary.entity.DietEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DietRepository extends JpaRepository<DietEntity, Long> {
+
+}

--- a/src/main/java/com/project/trainingdiary/service/DietService.java
+++ b/src/main/java/com/project/trainingdiary/service/DietService.java
@@ -1,0 +1,66 @@
+package com.project.trainingdiary.service;
+
+import com.project.trainingdiary.dto.request.CreateDietRequestDto;
+import com.project.trainingdiary.dto.response.DietImageResponseDto;
+import com.project.trainingdiary.entity.DietEntity;
+import com.project.trainingdiary.entity.TraineeEntity;
+import com.project.trainingdiary.exception.impl.InvalidFileTypeException;
+import com.project.trainingdiary.exception.impl.TraineeNotExistException;
+import com.project.trainingdiary.repository.DietRepository;
+import com.project.trainingdiary.repository.TraineeRepository;
+import com.project.trainingdiary.util.ImageUtil;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class DietService {
+
+  private final DietRepository dietRepository;
+  private final TraineeRepository traineeRepository;
+  private final ImageUtil imageUtil;
+
+  @Transactional
+  public DietImageResponseDto createDiet(CreateDietRequestDto dto) throws IOException {
+    TraineeEntity trainee = getTrainee();
+    List<String> originalUrls = new ArrayList<>();
+    List<String> thumbnailUrls = new ArrayList<>();
+
+    for (MultipartFile imageFile : dto.getImages()) {
+      if (!imageUtil.isValidImageType(imageFile)) {
+        throw new InvalidFileTypeException();
+      }
+
+      String originalUrl = imageUtil.uploadImageToS3(imageFile);
+      String extension = imageUtil.getExtension(imageFile.getOriginalFilename());
+      String thumbnailUrl = imageUtil.createAndUploadThumbnail(imageFile, originalUrl, extension);
+      originalUrls.add(originalUrl);
+      thumbnailUrls.add(thumbnailUrl);
+    }
+
+    DietEntity diet = new DietEntity();
+    diet.setTrainee(trainee);
+    diet.setContent(dto.getContent());
+    diet.setOriginalUrl(String.join(",", originalUrls)); // 여러 이미지 URL을 콤마로 구분
+    diet.setThumbnailUrl(String.join(",", thumbnailUrls)); // 여러 썸네일 URL을 콤마로 구분
+
+    dietRepository.save(diet);
+
+    return DietImageResponseDto.builder()
+        .originalUrl(originalUrls)
+        .thumbnailUrl(thumbnailUrls)
+        .build();
+  }
+
+  private TraineeEntity getTrainee() {
+    return traineeRepository
+        .findByEmail(SecurityContextHolder.getContext().getAuthentication().getName())
+        .orElseThrow(TraineeNotExistException::new);
+  }
+}

--- a/src/main/java/com/project/trainingdiary/util/ImageUtil.java
+++ b/src/main/java/com/project/trainingdiary/util/ImageUtil.java
@@ -1,0 +1,84 @@
+package com.project.trainingdiary.util;
+
+import io.awspring.cloud.s3.ObjectMetadata;
+import io.awspring.cloud.s3.S3Operations;
+import io.awspring.cloud.s3.S3Resource;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+import javax.imageio.ImageIO;
+import lombok.RequiredArgsConstructor;
+import org.imgscalr.Scalr;
+import org.imgscalr.Scalr.Method;
+import org.imgscalr.Scalr.Mode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+@Component
+@RequiredArgsConstructor
+public class ImageUtil {
+
+  private final S3Operations s3Operations;
+
+  @Value("${spring.cloud.aws.s3.bucket}")
+  private String bucket;
+
+  private static final int THUMBNAIL_WIDTH = 150;
+  private static final int THUMBNAIL_HEIGHT = 150;
+
+  public String uploadImageToS3(MultipartFile file) throws IOException {
+    String extension = getExtension(file.getOriginalFilename());
+    String key = UUID.randomUUID() + "." + extension;
+
+    try (InputStream inputStream = file.getInputStream()) {
+      S3Resource s3Resource = s3Operations.upload(bucket, key, inputStream,
+          ObjectMetadata.builder().contentType(file.getContentType()).build());
+      return s3Resource.getURL().toExternalForm();
+    }
+  }
+
+  public String createAndUploadThumbnail(MultipartFile file, String originalKey, String extension)
+      throws IOException {
+    BufferedImage originalImage = ImageIO.read(file.getInputStream());
+    BufferedImage thumbnailImage = Scalr
+        .resize(originalImage, Method.QUALITY, Mode.AUTOMATIC, THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT);
+
+    try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream()) {
+      ImageIO.write(thumbnailImage, extension, byteArrayOutputStream);
+      try (InputStream inputStream = new ByteArrayInputStream(
+          byteArrayOutputStream.toByteArray())) {
+        String thumbnailKey = "thumb_" + originalKey;
+        S3Resource s3Resource = s3Operations.upload(bucket, thumbnailKey, inputStream,
+            ObjectMetadata.builder().contentType(getMediaType(extension)).build());
+        return s3Resource.getURL().toExternalForm();
+      }
+    }
+  }
+
+  public boolean isValidImageType(MultipartFile file) {
+    return MediaType.IMAGE_JPEG.toString().equals(file.getContentType()) ||
+        MediaType.IMAGE_PNG.toString().equals(file.getContentType());
+  }
+
+  public String getExtension(String filename) {
+    if (filename == null) {
+      return "";
+    }
+    int dotIndex = filename.lastIndexOf('.');
+    return (dotIndex == -1) ? "" : filename.substring(dotIndex + 1);
+  }
+
+  private String getMediaType(String extension) {
+    if ("jpg".equalsIgnoreCase(extension) || "jpeg".equalsIgnoreCase(extension)) {
+      return MediaType.IMAGE_JPEG_VALUE;
+    } else if ("png".equalsIgnoreCase(extension)) {
+      return MediaType.IMAGE_PNG_VALUE;
+    }
+    return MediaType.APPLICATION_OCTET_STREAM_VALUE;
+  }
+}

--- a/src/main/java/com/project/trainingdiary/util/ImageUtil.java
+++ b/src/main/java/com/project/trainingdiary/util/ImageUtil.java
@@ -52,7 +52,7 @@ public class ImageUtil {
       ImageIO.write(thumbnailImage, extension, byteArrayOutputStream);
       try (InputStream inputStream = new ByteArrayInputStream(
           byteArrayOutputStream.toByteArray())) {
-        String thumbnailKey = "thumb_" + originalKey;
+        String thumbnailKey = "thumb_" + originalKey.substring(originalKey.lastIndexOf("/") + 1);
         S3Resource s3Resource = s3Operations.upload(bucket, thumbnailKey, inputStream,
             ObjectMetadata.builder().contentType(getMediaType(extension)).build());
         return s3Resource.getURL().toExternalForm();

--- a/src/test/java/com/project/trainingdiary/service/DietServiceTest.java
+++ b/src/test/java/com/project/trainingdiary/service/DietServiceTest.java
@@ -1,0 +1,222 @@
+package com.project.trainingdiary.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.project.trainingdiary.dto.request.CreateDietRequestDto;
+import com.project.trainingdiary.dto.response.DietImageResponseDto;
+import com.project.trainingdiary.entity.DietEntity;
+import com.project.trainingdiary.entity.TraineeEntity;
+import com.project.trainingdiary.exception.impl.InvalidFileTypeException;
+import com.project.trainingdiary.exception.impl.TraineeNotExistException;
+import com.project.trainingdiary.model.UserPrincipal;
+import com.project.trainingdiary.model.UserRoleType;
+import com.project.trainingdiary.repository.DietRepository;
+import com.project.trainingdiary.repository.TraineeRepository;
+import com.project.trainingdiary.util.ImageUtil;
+import io.awspring.cloud.s3.S3Operations;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import javax.imageio.ImageIO;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class DietServiceTest {
+
+  @Mock
+  private DietRepository dietRepository;
+
+  @Mock
+  private TraineeRepository traineeRepository;
+
+  @Mock
+  private ImageUtil imageUtil;
+
+  @Mock
+  private S3Operations s3Operations;
+
+  @InjectMocks
+  private DietService dietService;
+
+  private TraineeEntity trainee;
+
+  @BeforeEach
+  public void setUp() {
+    setupTrainee();
+  }
+
+  private void setupTrainee() {
+    trainee = TraineeEntity.builder()
+        .id(10L)
+        .email("trainee@example.com")
+        .name("김트레이니")
+        .role(UserRoleType.TRAINEE)
+        .build();
+  }
+
+  private void setupTraineeAuth() {
+    GrantedAuthority authority = new SimpleGrantedAuthority("ROLE_TRAINEE");
+    Collection authorities = Collections.singleton(authority);
+
+    Authentication authentication = mock(Authentication.class);
+    lenient().when(authentication.getAuthorities()).thenReturn(authorities);
+
+    UserDetails userDetails = UserPrincipal.create(trainee);
+    lenient().when(authentication.getPrincipal()).thenReturn(userDetails);
+    lenient().when(authentication.getName()).thenReturn(trainee.getEmail());
+
+    SecurityContext securityContext = mock(SecurityContext.class);
+    lenient().when(securityContext.getAuthentication()).thenReturn(authentication);
+    SecurityContextHolder.setContext(securityContext);
+
+    lenient().when(traineeRepository.findByEmail(trainee.getEmail()))
+        .thenReturn(Optional.of(trainee));
+  }
+
+
+  @AfterEach
+  void cleanup() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  @DisplayName("이미지 업로드 실패 - 파일 타입이 맞지 않으면 예외 발생")
+  void testCreateDietFailInvalidFileType() throws IOException {
+    setupTraineeAuth();
+
+    when(traineeRepository.findByEmail("trainee@example.com")).thenReturn(Optional.of(trainee));
+
+    MockMultipartFile mockFile = new MockMultipartFile(
+        "file", "test.txt", "text/plain", "test text content".getBytes());
+
+    CreateDietRequestDto dto = CreateDietRequestDto.builder()
+        .content("Test content")
+        .images(List.of(mockFile))
+        .build();
+
+    assertThrows(InvalidFileTypeException.class,
+        () -> dietService.createDiet(dto));
+
+    ArgumentCaptor<DietEntity> dietCaptor = ArgumentCaptor.forClass(DietEntity.class);
+    ArgumentCaptor<String> bucketCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<InputStream> inputStreamCaptor = ArgumentCaptor.forClass(InputStream.class);
+
+    verify(dietRepository, never()).save(dietCaptor.capture());
+    verify(imageUtil, never()).uploadImageToS3(any());
+    verify(imageUtil, never()).createAndUploadThumbnail(any(), any(), any());
+
+    assertTrue(dietCaptor.getAllValues().isEmpty());
+    assertTrue(bucketCaptor.getAllValues().isEmpty());
+    assertTrue(keyCaptor.getAllValues().isEmpty());
+    assertTrue(inputStreamCaptor.getAllValues().isEmpty());
+  }
+
+  @Test
+  @DisplayName("이미지 업로드 성공")
+  void testCreateDietSuccess() throws IOException {
+    setupTraineeAuth();
+
+    when(traineeRepository.findByEmail("trainee@example.com")).thenReturn(Optional.of(trainee));
+
+    BufferedImage img = new BufferedImage(500, 500, BufferedImage.TYPE_INT_RGB);
+    Graphics2D g2d = img.createGraphics();
+    g2d.setColor(Color.RED);
+    g2d.fillRect(0, 0, 500, 500);
+    g2d.dispose();
+
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    ImageIO.write(img, "jpg", byteArrayOutputStream);
+    byte[] imageBytes = byteArrayOutputStream.toByteArray();
+    MockMultipartFile mockFile = new MockMultipartFile(
+        "file", "test.jpg", "image/jpeg", imageBytes);
+
+    CreateDietRequestDto dto = CreateDietRequestDto.builder()
+        .content("Test content")
+        .images(List.of(mockFile))
+        .build();
+
+    when(imageUtil.isValidImageType(mockFile)).thenReturn(true);
+
+    when(imageUtil.uploadImageToS3(mockFile)).thenReturn(
+        "https://test-bucket.s3.amazonaws.com/original.jpg");
+
+    when(imageUtil.getExtension("test.jpg")).thenReturn("jpg");
+    when(imageUtil.createAndUploadThumbnail(mockFile,
+        "https://test-bucket.s3.amazonaws.com/original.jpg", "jpg"))
+        .thenReturn("https://test-bucket.s3.amazonaws.com/thumb_original.jpg");
+
+    DietImageResponseDto response = dietService.createDiet(dto);
+
+    ArgumentCaptor<DietEntity> dietCaptor = ArgumentCaptor.forClass(DietEntity.class);
+    verify(dietRepository, times(1)).save(dietCaptor.capture());
+    DietEntity savedDiet = dietCaptor.getValue();
+
+    assertEquals("Test content", savedDiet.getContent());
+    assertEquals(trainee, savedDiet.getTrainee());
+    assertEquals("https://test-bucket.s3.amazonaws.com/original.jpg", savedDiet.getOriginalUrl());
+    assertEquals("https://test-bucket.s3.amazonaws.com/thumb_original.jpg",
+        savedDiet.getThumbnailUrl());
+
+    assertNotNull(response);
+    assertEquals(1, response.getOriginalUrl().size());
+    assertEquals(1, response.getThumbnailUrl().size());
+    assertTrue(
+        response.getOriginalUrl().contains("https://test-bucket.s3.amazonaws.com/original.jpg"));
+    assertTrue(response.getThumbnailUrl()
+        .contains("https://test-bucket.s3.amazonaws.com/thumb_original.jpg"));
+  }
+
+  @Test
+  @DisplayName("트레이니를 찾을 수 없음 - 예외 발생")
+  void testCreateDietTraineeNotFound() {
+    setupTraineeAuth();
+
+    when(traineeRepository.findByEmail("trainee@example.com")).thenReturn(Optional.empty());
+
+    MockMultipartFile image = new MockMultipartFile("image", "image.jpg", "image/jpeg",
+        "image content".getBytes());
+
+    CreateDietRequestDto dto = CreateDietRequestDto.builder()
+        .content("Test content")
+        .images(List.of(image))
+        .build();
+
+    assertThrows(TraineeNotExistException.class, () -> dietService.createDiet(dto));
+  }
+}


### PR DESCRIPTION
### 변경사항

- **식단 기능 API 추가**:
  - 식단 생성 API (`POST /api/diets/`) 구현.
  - 각 메서드에 주석 추가하여 이해하기 쉽게 개선.
 
### 관련 이슈 및 반영 브랜치

- **Issue** : #69  

- **Branch:**
  - FROM: `feature/create-diet`
  - TO: `master`

---

## 설명

이번 변경사항은 트레이니가 식단을 생성할 수 있는 기능을 포함하고 있습니다. 트레이니가 이미지를 업로드하고 텍스트 또는 콘텐츠를 추가할 수 있도록 하였습니다.

### ASIS

- 트레이니가 식단을 생성하거나 이미지를 업로드할 수 있는 기능이 없었습니다.

### TOBE

- 트레이니는 식단을 생성할 수 있습니다.
- 트레이니는 이미지를 업로드하고 텍스트 또는 콘텐츠를 추가할 수 있습니다.

### 테스트

- 식단 생성 API에 대한 유닛 테스트를 실행하여 올바르게 작동하는지 확인하였습니다.
- 수동 테스트를 통해 각 기능이 예상대로 작동하는지 확인하였습니다.

### 추가 테스트 시나리오

- 식단 생성 시 잘못된 이미지 파일 형식을 업로드하면 실패하는지 확인.
- 식단 생성 시 여러 이미지를 업로드할 수 있는지 확인.
- 이미지 업로드 시 썸네일이 올바르게 생성되는지 확인.
- 이미지를 S3에 성공적으로 업로드하고 썸네일도 올바르게 저장되는지 확인.

### 참고 사항

- 새로운 API가 다른 서비스 및 구성 요소와 호환되는지 확인해야 합니다.
- 각 기능에 대한 추가 검증이 필요할 수 있습니다.

---

### API 문서

#### POST /api/diets/ - 식단 생성

```json
{
  "content": "오늘의 식단",
  "images": [
    "data:image/jpeg;base64,...",
    "data:image/jpeg;base64,..."
  ]
}
```

#### 응답

```json
{
  "originalUrl": [
    "https://test-bucket.s3.amazonaws.com/original1.jpg",
    "https://test-bucket.s3.amazonaws.com/original2.jpg"
  ],
  "thumbnailUrl": [
    "https://test-bucket.s3.amazonaws.com/thumb_original1.jpg",
    "https://test-bucket.s3.amazonaws.com/thumb_original2.jpg"
  ]
}
```

### 결론

이번 변경사항을 통해 트레이니가 식단을 생성하고 이미지를 업로드할 수 있는 기능을 구현하였습니다. 이미지는 S3에 성공적으로 저장되며, 썸네일 또한 올바르게 생성 및 저장됩니다. 이를 통해 시스템의 기능성과 사용자 편의성을 향상시켰습니다. 새로운 API에 대한 자세한 내용은 위의 API 문서를 참고하시기 바랍니다.