### PR TITLE
PT 계약의 시간 표시를 KST로 수정

### DIFF
--- a/src/main/java/com/project/trainingdiary/dto/response/PtContractResponseDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/response/PtContractResponseDto.java
@@ -1,6 +1,7 @@
 package com.project.trainingdiary.dto.response;
 
-import java.time.LocalDateTime;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.ZonedDateTime;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -11,7 +12,9 @@ import lombok.Setter;
 public class PtContractResponseDto {
 
   private Long ptContractId;
-  private LocalDateTime totalSessionUpdatedAt;
+
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX", timezone = "Asia/Seoul")
+  private ZonedDateTime totalSessionUpdatedAt;
   private int remainingSession;
   private Long trainerId;
   private String trainerName;

--- a/src/main/java/com/project/trainingdiary/entity/PtContractEntity.java
+++ b/src/main/java/com/project/trainingdiary/entity/PtContractEntity.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -85,7 +86,7 @@ public class PtContractEntity extends BaseEntity {
         .traineeId(trainee.getId())
         .traineeName(trainee.getName())
         .remainingSession(getRemainingSession())
-        .totalSessionUpdatedAt(totalSessionUpdatedAt)
+        .totalSessionUpdatedAt(totalSessionUpdatedAt.atZone(ZoneId.of("Asia/Seoul")))
         .build();
   }
 }


### PR DESCRIPTION
### 변경사항

<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요 -->
**AS-IS**
- PT 계약의 시간 표시를 UTC로 하고 있음

**TO-BE**
- PT 계약의 시간 표시를 KST로 표현

### 테스트

<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 

- [x] API 테스트
GET /api/pt-contracts 에서 totalSessionUpdatedAt 필드
```
"totalSessionUpdatedAt": "2024-07-19T10:29:50.307+09:00",
```

Resolves #73 