### PR TITLE
식단 목록 조회 기능 (트레이너, 트레이니 둘 다 가능) API 구현

### DIFF
--- a/src/main/java/com/project/trainingdiary/controller/DietController.java
+++ b/src/main/java/com/project/trainingdiary/controller/DietController.java
@@ -8,14 +8,16 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.IOException;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -39,27 +41,29 @@ public class DietController {
   })
   @PreAuthorize("hasRole('TRAINEE')")
   @PostMapping
-  public ResponseEntity<DietImageResponseDto> createDiet(
-      @RequestPart("images") List<MultipartFile> images,
+  public ResponseEntity<Void> createDiet(
+      @RequestPart("image") MultipartFile image,
       @RequestPart("content") String content
   ) throws IOException {
     CreateDietRequestDto dto = CreateDietRequestDto.builder()
-        .images(images)
+        .image(image)
         .content(content)
         .build();
 
-    DietImageResponseDto response = dietService.createDiet(dto);
-    return ResponseEntity.ok(response);
+    dietService.createDiet(dto);
+    return ResponseEntity.ok().build();
   }
 
-  @PreAuthorize("hasRole('TRAINER')")
-  @GetMapping
-  public ResponseEntity<Page<DietImageResponseDto>> getDiets(
+  @Operation(summary = "식단 목록 조회", description = "트레이니의 식단 목록을 페이징하여 조회합니다.")
+  @GetMapping("{id}")
+  public ResponseEntity<Page<DietImageResponseDto>> getTraineeDiets(
+      @PathVariable Long id,
       @RequestParam(defaultValue = "0") int page,
-      @RequestParam(defaultValue = "12") int size
+      @RequestParam(defaultValue = "9") int size
   ) {
-    Pageable pageable = PageRequest.of(page, size);
-    Page<DietImageResponseDto> diets = dietService.getDiets(pageable);
+    Sort.Direction direction = Direction.DESC;
+    Pageable pageable = PageRequest.of(page, size, Sort.by(direction, "createdAt"));
+    Page<DietImageResponseDto> diets = dietService.getDiets(id, pageable);
 
     return ResponseEntity.ok(diets);
   }

--- a/src/main/java/com/project/trainingdiary/controller/DietController.java
+++ b/src/main/java/com/project/trainingdiary/controller/DietController.java
@@ -12,6 +12,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -26,7 +27,9 @@ public class DietController {
 
   private final DietService dietService;
 
-  @Operation(summary = "식단 생성", description = "트레이니가 이미지를 업로드하고 식단 내용을 추가하여 식단을 생성합니다.")
+  @Operation(
+      summary = "식단 생성", description = "트레이니가 이미지를 업로드하고 식단 내용을 추가하여 식단을 생성합니다."
+  )
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "성공"),
   })
@@ -44,4 +47,12 @@ public class DietController {
     DietImageResponseDto response = dietService.createDiet(dto);
     return ResponseEntity.ok(response);
   }
+
+  @PreAuthorize("hasRole('TRAINEE')")
+  @GetMapping
+  public ResponseEntity<List<DietImageResponseDto>> getDiets() {
+    List<DietImageResponseDto> diets = dietService.getDiets();
+    return ResponseEntity.ok(diets);
+  }
+
 }

--- a/src/main/java/com/project/trainingdiary/controller/DietController.java
+++ b/src/main/java/com/project/trainingdiary/controller/DietController.java
@@ -10,11 +10,15 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -48,11 +52,15 @@ public class DietController {
     return ResponseEntity.ok(response);
   }
 
-  @PreAuthorize("hasRole('TRAINEE')")
+  @PreAuthorize("hasRole('TRAINER')")
   @GetMapping
-  public ResponseEntity<List<DietImageResponseDto>> getDiets() {
-    List<DietImageResponseDto> diets = dietService.getDiets();
+  public ResponseEntity<Page<DietImageResponseDto>> getDiets(
+      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "12") int size
+  ) {
+    Pageable pageable = PageRequest.of(page, size);
+    Page<DietImageResponseDto> diets = dietService.getDiets(pageable);
+
     return ResponseEntity.ok(diets);
   }
-
 }

--- a/src/main/java/com/project/trainingdiary/controller/TrainerController.java
+++ b/src/main/java/com/project/trainingdiary/controller/TrainerController.java
@@ -30,7 +30,10 @@ public class TrainerController {
 
   private final TrainerService trainerService;
 
-  @Operation(summary = "트레이니 정보 조회", description = "트레이너가 트레이니 정보를 조회합니다.")
+  @Operation(
+      summary = "트레이니 정보 조회",
+      description = "트레이너가 트레이니 정보를 조회합니다."
+  )
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "조회 성공"),
   })
@@ -43,7 +46,10 @@ public class TrainerController {
     return ResponseEntity.ok(traineeInfo);
   }
 
-  @Operation(summary = "트레이니 정보 수정", description = "트레이너가 트레이니 정보를 수정합니다.")
+  @Operation(
+      summary = "트레이니 정보 수정",
+      description = "트레이너가 트레이니 정보를 수정합니다."
+  )
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "수정 성공"),
   })
@@ -56,7 +62,10 @@ public class TrainerController {
     return ResponseEntity.ok(editTraineeInfo);
   }
 
-  @Operation(summary = "트레이니 인바디 정보 추가", description = "트레이너가 트레이니의 인바디 정보를 추가합니다.")
+  @Operation(
+      summary = "트레이니 인바디 정보 추가",
+      description = "트레이너가 트레이니의 인바디 정보를 추가합니다."
+  )
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "추가 성공"),
   })

--- a/src/main/java/com/project/trainingdiary/controller/UserController.java
+++ b/src/main/java/com/project/trainingdiary/controller/UserController.java
@@ -30,7 +30,10 @@ public class UserController {
 
   private final UserService userService;
 
-  @Operation(summary = "이메일 중복 확인 및 인증 코드 발송", description = "이메일 중복 여부를 확인하고 인증 코드를 발송합니다.")
+  @Operation(
+      summary = "이메일 중복 확인 및 인증 코드 발송",
+      description = "이메일 중복 여부를 확인하고 인증 코드를 발송합니다."
+  )
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "성공")
   })
@@ -42,7 +45,10 @@ public class UserController {
     return ResponseEntity.ok().build();
   }
 
-  @Operation(summary = "인증 코드 확인", description = "사용자 이메일로 전송된 인증 코드를 확인합니다.")
+  @Operation(
+      summary = "인증 코드 확인",
+      description = "사용자 이메일로 전송된 인증 코드를 확인합니다."
+  )
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "성공")
   })
@@ -54,7 +60,10 @@ public class UserController {
     return ResponseEntity.ok().build();
   }
 
-  @Operation(summary = "회원 가입", description = "새로운 사용자를 등록합니다.")
+  @Operation(
+      summary = "회원 가입",
+      description = "새로운 사용자를 등록합니다."
+  )
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "성공"),
   })
@@ -66,7 +75,10 @@ public class UserController {
     return ResponseEntity.ok().build();
   }
 
-  @Operation(summary = "로그인", description = "사용자를 인증하고 토큰을 반환합니다.")
+  @Operation(
+      summary = "로그인",
+      description = "사용자를 인증하고 토큰을 반환합니다."
+  )
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "성공"),
   })
@@ -78,7 +90,10 @@ public class UserController {
     return ResponseEntity.ok(signInResponse);
   }
 
-  @Operation(summary = "로그아웃", description = "사용자를 로그아웃합니다.")
+  @Operation(
+      summary = "로그아웃",
+      description = "사용자를 로그아웃합니다."
+  )
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "성공")
   })
@@ -90,7 +105,10 @@ public class UserController {
     return ResponseEntity.ok().build();
   }
 
-  @Operation(summary = "사용자 정보 조회", description = "인증된 사용자의 정보를 조회합니다.")
+  @Operation(
+      summary = "사용자 정보 조회",
+      description = "인증된 사용자의 정보를 조회합니다."
+  )
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "성공"),
   })

--- a/src/main/java/com/project/trainingdiary/dto/request/CreateDietRequestDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/request/CreateDietRequestDto.java
@@ -10,5 +10,5 @@ import org.springframework.web.multipart.MultipartFile;
 public class CreateDietRequestDto {
 
   private String content;
-  List<MultipartFile> images;
+  private MultipartFile image;
 }

--- a/src/main/java/com/project/trainingdiary/dto/request/CreateDietRequestDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/request/CreateDietRequestDto.java
@@ -1,6 +1,5 @@
 package com.project.trainingdiary.dto.request;
 
-import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.web.multipart.MultipartFile;

--- a/src/main/java/com/project/trainingdiary/dto/response/DietImageResponseDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/response/DietImageResponseDto.java
@@ -12,6 +12,7 @@ import lombok.Setter;
 @Builder
 public class DietImageResponseDto {
 
+  private Long dietId;
   private List<String> originalUrl;
   private List<String> thumbnailUrl;
   private String content;

--- a/src/main/java/com/project/trainingdiary/dto/response/DietImageResponseDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/response/DietImageResponseDto.java
@@ -1,6 +1,5 @@
 package com.project.trainingdiary.dto.response;
 
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,7 +12,5 @@ import lombok.Setter;
 public class DietImageResponseDto {
 
   private Long dietId;
-  private List<String> originalUrl;
-  private List<String> thumbnailUrl;
-  private String content;
+  private String thumbnailUrl;
 }

--- a/src/main/java/com/project/trainingdiary/dto/response/DietImageResponseDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/response/DietImageResponseDto.java
@@ -14,4 +14,5 @@ public class DietImageResponseDto {
 
   private List<String> originalUrl;
   private List<String> thumbnailUrl;
+  private String content;
 }

--- a/src/main/java/com/project/trainingdiary/repository/DietRepository.java
+++ b/src/main/java/com/project/trainingdiary/repository/DietRepository.java
@@ -1,8 +1,11 @@
 package com.project.trainingdiary.repository;
 
 import com.project.trainingdiary.entity.DietEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DietRepository extends JpaRepository<DietEntity, Long> {
 
+  Page<DietEntity> findByTraineeId(Long traineeId, Pageable pageable);
 }

--- a/src/main/java/com/project/trainingdiary/service/DietService.java
+++ b/src/main/java/com/project/trainingdiary/service/DietService.java
@@ -4,18 +4,21 @@ import com.project.trainingdiary.dto.request.CreateDietRequestDto;
 import com.project.trainingdiary.dto.response.DietImageResponseDto;
 import com.project.trainingdiary.entity.DietEntity;
 import com.project.trainingdiary.entity.TraineeEntity;
+import com.project.trainingdiary.entity.TrainerEntity;
 import com.project.trainingdiary.exception.impl.InvalidFileTypeException;
+import com.project.trainingdiary.exception.impl.PtContractNotExistException;
 import com.project.trainingdiary.exception.impl.TraineeNotExistException;
+import com.project.trainingdiary.exception.impl.UserNotFoundException;
 import com.project.trainingdiary.repository.DietRepository;
 import com.project.trainingdiary.repository.TraineeRepository;
+import com.project.trainingdiary.repository.TrainerRepository;
+import com.project.trainingdiary.repository.ptContract.PtContractRepository;
 import com.project.trainingdiary.util.ImageUtil;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,55 +30,122 @@ public class DietService {
 
   private final DietRepository dietRepository;
   private final TraineeRepository traineeRepository;
+  private final TrainerRepository trainerRepository;
+  private final PtContractRepository ptContractRepository;
   private final ImageUtil imageUtil;
 
+  /**
+   * 새로운 식단을 생성합니다.
+   *
+   * @param dto 식단 생성 요청 DTO
+   * @throws IOException              이미지 업로드 중 오류 발생 시 예외 발생
+   * @throws InvalidFileTypeException 이미지 파일 타입이 유효하지 않을 경우 예외 발생
+   */
   @Transactional
-  public DietImageResponseDto createDiet(CreateDietRequestDto dto) throws IOException {
-    TraineeEntity trainee = getTrainee();
-    List<String> originalUrls = new ArrayList<>();
-    List<String> thumbnailUrls = new ArrayList<>();
+  public void createDiet(CreateDietRequestDto dto) throws IOException {
+    TraineeEntity trainee = getAuthenticatedTrainee();
+    MultipartFile imageFile = dto.getImage();
 
-    for (MultipartFile imageFile : dto.getImages()) {
-      if (!imageUtil.isValidImageType(imageFile)) {
-        throw new InvalidFileTypeException();
-      }
-
-      String originalUrl = imageUtil.uploadImageToS3(imageFile);
-      String extension = imageUtil.getExtension(imageFile.getOriginalFilename());
-      String thumbnailUrl = imageUtil.createAndUploadThumbnail(imageFile, originalUrl, extension);
-      originalUrls.add(originalUrl);
-      thumbnailUrls.add(thumbnailUrl);
+    if (!imageUtil.isValidImageType(imageFile)) {
+      throw new InvalidFileTypeException();
     }
+
+    String originalUrl = imageUtil.uploadImageToS3(imageFile);
+    String extension = imageUtil.getExtension(imageFile.getOriginalFilename());
+    String thumbnailUrl = imageUtil.createAndUploadThumbnail(imageFile, originalUrl, extension);
 
     DietEntity diet = new DietEntity();
     diet.setTrainee(trainee);
     diet.setContent(dto.getContent());
-    diet.setOriginalUrl(String.join(",", originalUrls)); // 여러 이미지 URL을 콤마로 구분
-    diet.setThumbnailUrl(String.join(",", thumbnailUrls)); // 여러 썸네일 URL을 콤마로 구분
+    diet.setOriginalUrl(originalUrl);
+    diet.setThumbnailUrl(thumbnailUrl);
 
     dietRepository.save(diet);
-
-    return DietImageResponseDto.builder()
-        .dietId(diet.getId())
-        .originalUrl(originalUrls)
-        .thumbnailUrl(thumbnailUrls)
-        .content(dto.getContent())
-        .build();
   }
 
-  public Page<DietImageResponseDto> getDiets(Pageable pageable) {
-    Page<DietEntity> dietPage = dietRepository.findAll(pageable);
+  /**
+   * 트레이니 또는 트레이너가 식단 목록을 조회합니다.
+   *
+   * @param id       조회할 트레이니의 ID
+   * @param pageable 페이지 요청 정보
+   * @return 트레이니의 식단 페이지
+   * @throws PtContractNotExistException 트레이너와 트레이니 사이에 계약이 없을 경우 예외 발생
+   * @throws UserNotFoundException       인증된 사용자가 트레이니 또는 트레이너가 아닐 경우 예외 발생
+   */
+  public Page<DietImageResponseDto> getDiets(Long id, Pageable pageable) {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    String userEmail = authentication.getName();
+
+    TraineeEntity trainee = traineeRepository.findByEmail(userEmail).orElse(null);
+    TrainerEntity trainer = trainerRepository.findByEmail(userEmail).orElse(null);
+
+    if (trainee != null && trainee.getId().equals(id)) {
+      return getDietsForTrainee(trainee, pageable);
+    } else if (trainer != null) {
+      TraineeEntity traineeToView = getTraineeById(id);
+      if (hasContractWithTrainee(trainer, traineeToView)) {
+        return getDietsForTrainee(traineeToView, pageable);
+      } else {
+        throw new PtContractNotExistException();
+      }
+    } else {
+      throw new UserNotFoundException();
+    }
+  }
+
+  /**
+   * 트레이니의 식단 목록을 조회합니다.
+   *
+   * @param trainee  트레이니 엔티티
+   * @param pageable 페이지 요청 정보
+   * @return 트레이니의 식단 페이지
+   */
+  private Page<DietImageResponseDto> getDietsForTrainee(TraineeEntity trainee, Pageable pageable) {
+    Page<DietEntity> dietPage = dietRepository.findByTraineeId(trainee.getId(), pageable);
 
     return dietPage.map(diet -> DietImageResponseDto.builder()
         .dietId(diet.getId())
-        .thumbnailUrl(Collections.singletonList(diet.getThumbnailUrl().split(",")[0]))
-        .content(diet.getContent())
+        .thumbnailUrl(diet.getThumbnailUrl())
         .build());
   }
 
-  private TraineeEntity getTrainee() {
-    return traineeRepository
-        .findByEmail(SecurityContextHolder.getContext().getAuthentication().getName())
+  /**
+   * 트레이너가 트레이니와 계약을 맺고 있는지 확인합니다.
+   *
+   * @param trainer 트레이너 엔티티
+   * @param trainee 트레이니 엔티티
+   * @return 계약 여부
+   */
+  private boolean hasContractWithTrainee(TrainerEntity trainer, TraineeEntity trainee) {
+    return ptContractRepository.findByTrainerIdAndTraineeId(trainer.getId(), trainee.getId())
+        .isPresent();
+  }
+
+  /**
+   * 인증된 트레이니를 조회합니다.
+   *
+   * @return 인증된 트레이니 엔티티
+   * @throws TraineeNotExistException 인증된 트레이니가 존재하지 않을 경우 예외 발생
+   */
+  private TraineeEntity getAuthenticatedTrainee() {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication == null || authentication.getName() == null) {
+      throw new TraineeNotExistException();
+    }
+    String email = authentication.getName();
+    return traineeRepository.findByEmail(email)
+        .orElseThrow(TraineeNotExistException::new);
+  }
+
+  /**
+   * 트레이니 ID로 트레이니를 조회합니다.
+   *
+   * @param id 트레이니의 ID
+   * @return 트레이니 엔티티
+   * @throws TraineeNotExistException 트레이니가 존재하지 않을 경우 예외 발생
+   */
+  private TraineeEntity getTraineeById(Long id) {
+    return traineeRepository.findById(id)
         .orElseThrow(TraineeNotExistException::new);
   }
 }

--- a/src/main/java/com/project/trainingdiary/service/DietService.java
+++ b/src/main/java/com/project/trainingdiary/service/DietService.java
@@ -11,6 +11,7 @@ import com.project.trainingdiary.repository.TraineeRepository;
 import com.project.trainingdiary.util.ImageUtil;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -55,6 +56,7 @@ public class DietService {
     return DietImageResponseDto.builder()
         .originalUrl(originalUrls)
         .thumbnailUrl(thumbnailUrls)
+        .content(dto.getContent())
         .build();
   }
 
@@ -62,5 +64,16 @@ public class DietService {
     return traineeRepository
         .findByEmail(SecurityContextHolder.getContext().getAuthentication().getName())
         .orElseThrow(TraineeNotExistException::new);
+  }
+
+  public List<DietImageResponseDto> getDiets() {
+    List<DietEntity> diets = dietRepository.findAll();
+    return diets.stream()
+        .map(diet -> DietImageResponseDto.builder()
+            .originalUrl(Arrays.stream(diet.getOriginalUrl().split(",")).toList())
+            .thumbnailUrl(Arrays.stream(diet.getThumbnailUrl().split(",")).toList())
+            .content(diet.getContent())
+            .build())
+        .toList();
   }
 }

--- a/src/test/java/com/project/trainingdiary/service/DietServiceTest.java
+++ b/src/test/java/com/project/trainingdiary/service/DietServiceTest.java
@@ -16,14 +16,18 @@ import com.project.trainingdiary.dto.request.CreateDietRequestDto;
 import com.project.trainingdiary.dto.response.DietImageResponseDto;
 import com.project.trainingdiary.entity.DietEntity;
 import com.project.trainingdiary.entity.TraineeEntity;
+import com.project.trainingdiary.entity.TrainerEntity;
 import com.project.trainingdiary.exception.impl.InvalidFileTypeException;
+import com.project.trainingdiary.exception.impl.PtContractNotExistException;
 import com.project.trainingdiary.exception.impl.TraineeNotExistException;
+import com.project.trainingdiary.exception.impl.UserNotFoundException;
 import com.project.trainingdiary.model.UserPrincipal;
 import com.project.trainingdiary.model.UserRoleType;
 import com.project.trainingdiary.repository.DietRepository;
 import com.project.trainingdiary.repository.TraineeRepository;
+import com.project.trainingdiary.repository.TrainerRepository;
+import com.project.trainingdiary.repository.ptContract.PtContractRepository;
 import com.project.trainingdiary.util.ImageUtil;
-import io.awspring.cloud.s3.S3Operations;
 import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
@@ -32,7 +36,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 import javax.imageio.ImageIO;
 import org.junit.jupiter.api.AfterEach;
@@ -46,6 +49,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -65,19 +72,30 @@ public class DietServiceTest {
   private TraineeRepository traineeRepository;
 
   @Mock
-  private ImageUtil imageUtil;
+  private TrainerRepository trainerRepository;
 
   @Mock
-  private S3Operations s3Operations;
+  private PtContractRepository ptContractRepository;
+
+  @Mock
+  private ImageUtil imageUtil;
+
 
   @InjectMocks
   private DietService dietService;
 
   private TraineeEntity trainee;
+  private TrainerEntity trainer;
 
   @BeforeEach
   public void setUp() {
     setupTrainee();
+    setupTrainer();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    SecurityContextHolder.clearContext();
   }
 
   private void setupTrainee() {
@@ -86,6 +104,15 @@ public class DietServiceTest {
         .email("trainee@example.com")
         .name("김트레이니")
         .role(UserRoleType.TRAINEE)
+        .build();
+  }
+
+  private void setupTrainer() {
+    trainer = TrainerEntity.builder()
+        .id(20L)
+        .email("trainer@example.com")
+        .name("김트레이너")
+        .role(UserRoleType.TRAINER)
         .build();
   }
 
@@ -108,6 +135,24 @@ public class DietServiceTest {
         .thenReturn(Optional.of(trainee));
   }
 
+  private void setupTrainerAuth() {
+    GrantedAuthority authority = new SimpleGrantedAuthority("ROLE_TRAINER");
+    Collection authorities = Collections.singleton(authority);
+
+    Authentication authentication = mock(Authentication.class);
+    lenient().when(authentication.getAuthorities()).thenReturn(authorities);
+
+    UserDetails userDetails = UserPrincipal.create(trainer);
+    lenient().when(authentication.getPrincipal()).thenReturn(userDetails);
+    lenient().when(authentication.getName()).thenReturn(trainer.getEmail());
+
+    SecurityContext securityContext = mock(SecurityContext.class);
+    lenient().when(securityContext.getAuthentication()).thenReturn(authentication);
+    SecurityContextHolder.setContext(securityContext);
+
+    lenient().when(trainerRepository.findByEmail(trainer.getEmail()))
+        .thenReturn(Optional.of(trainer));
+  }
 
   @AfterEach
   void cleanup() {
@@ -126,7 +171,7 @@ public class DietServiceTest {
 
     CreateDietRequestDto dto = CreateDietRequestDto.builder()
         .content("Test content")
-        .images(List.of(mockFile))
+        .image(mockFile)
         .build();
 
     assertThrows(InvalidFileTypeException.class,
@@ -168,7 +213,7 @@ public class DietServiceTest {
 
     CreateDietRequestDto dto = CreateDietRequestDto.builder()
         .content("Test content")
-        .images(List.of(mockFile))
+        .image(mockFile)
         .build();
 
     when(imageUtil.isValidImageType(mockFile)).thenReturn(true);
@@ -181,7 +226,7 @@ public class DietServiceTest {
         "https://test-bucket.s3.amazonaws.com/original.jpg", "jpg"))
         .thenReturn("https://test-bucket.s3.amazonaws.com/thumb_original.jpg");
 
-    DietImageResponseDto response = dietService.createDiet(dto);
+    dietService.createDiet(dto);
 
     ArgumentCaptor<DietEntity> dietCaptor = ArgumentCaptor.forClass(DietEntity.class);
     verify(dietRepository, times(1)).save(dietCaptor.capture());
@@ -193,13 +238,9 @@ public class DietServiceTest {
     assertEquals("https://test-bucket.s3.amazonaws.com/thumb_original.jpg",
         savedDiet.getThumbnailUrl());
 
-    assertNotNull(response);
-    assertEquals(1, response.getOriginalUrl().size());
-    assertEquals(1, response.getThumbnailUrl().size());
-    assertTrue(
-        response.getOriginalUrl().contains("https://test-bucket.s3.amazonaws.com/original.jpg"));
-    assertTrue(response.getThumbnailUrl()
-        .contains("https://test-bucket.s3.amazonaws.com/thumb_original.jpg"));
+    verify(imageUtil, times(1)).uploadImageToS3(mockFile);
+    verify(imageUtil, times(1)).createAndUploadThumbnail(mockFile,
+        "https://test-bucket.s3.amazonaws.com/original.jpg", "jpg");
   }
 
   @Test
@@ -208,15 +249,68 @@ public class DietServiceTest {
     setupTraineeAuth();
 
     when(traineeRepository.findByEmail("trainee@example.com")).thenReturn(Optional.empty());
-
     MockMultipartFile image = new MockMultipartFile("image", "image.jpg", "image/jpeg",
         "image content".getBytes());
 
     CreateDietRequestDto dto = CreateDietRequestDto.builder()
         .content("Test content")
-        .images(List.of(image))
+        .image(image)
         .build();
 
     assertThrows(TraineeNotExistException.class, () -> dietService.createDiet(dto));
+  }
+
+  @Test
+  @DisplayName("트레이니가 자신의 식단을 조회할 수 있음")
+  void testGetDietsForTrainee() {
+    setupTraineeAuth();
+    Pageable pageable = PageRequest.of(0, 10);
+    DietEntity diet = new DietEntity();
+    diet.setId(1L);
+    diet.setTrainee(trainee);
+    diet.setContent("Test content");
+    diet.setThumbnailUrl("https://test-bucket.s3.amazonaws.com/thumb_original.jpg");
+    Page<DietEntity> dietPage = new PageImpl<>(Collections.singletonList(diet), pageable, 1);
+    when(dietRepository.findByTraineeId(trainee.getId(), pageable)).thenReturn(dietPage);
+
+    Page<DietImageResponseDto> response = dietService.getDiets(trainee.getId(), pageable);
+
+    assertNotNull(response);
+    assertEquals(1, response.getTotalElements());
+    DietImageResponseDto responseDto = response.getContent().get(0);
+    assertEquals(diet.getId(), responseDto.getDietId());
+    assertTrue(responseDto.getThumbnailUrl()
+        .contains("https://test-bucket.s3.amazonaws.com/thumb_original.jpg"));
+  }
+
+  @Test
+  @DisplayName("트레이너가 트레이니의 식단을 조회할 수 없음 - 계약이 없는 경우")
+  void testGetDietsForTrainerWithoutContract() {
+    setupTrainerAuth();
+
+    TraineeEntity traineeToView = new TraineeEntity();
+    traineeToView.setId(1L);
+    when(traineeRepository.findById(1L)).thenReturn(Optional.of(traineeToView));
+
+    Pageable pageable = PageRequest.of(0, 10);
+    when(ptContractRepository.findByTrainerIdAndTraineeId(trainer.getId(), traineeToView.getId()))
+        .thenReturn(Optional.empty());
+
+    assertThrows(PtContractNotExistException.class,
+        () -> dietService.getDiets(traineeToView.getId(), pageable));
+  }
+
+  @Test
+  @DisplayName("사용자를 찾을 수 없음 - 예외 발생")
+  void testGetDietsUserNotFound() {
+    Authentication authentication = mock(Authentication.class);
+    lenient().when(authentication.getName()).thenReturn("unknown @example.com");
+
+    SecurityContext securityContext = mock(SecurityContext.class);
+    lenient().when(securityContext.getAuthentication()).thenReturn(authentication);
+    SecurityContextHolder.setContext(securityContext);
+
+    assertThrows(UserNotFoundException.class,
+        () -> dietService.getDiets(999L, PageRequest.of(0, 10)));
   }
 }

--- a/src/test/java/com/project/trainingdiary/service/DietServiceTest.java
+++ b/src/test/java/com/project/trainingdiary/service/DietServiceTest.java
@@ -310,7 +310,7 @@ public class DietServiceTest {
     lenient().when(securityContext.getAuthentication()).thenReturn(authentication);
     SecurityContextHolder.setContext(securityContext);
 
-    assertThrows(UserNotFoundException.class,
+    assertThrows(TraineeNotExistException.class,
         () -> dietService.getDiets(999L, PageRequest.of(0, 10)));
   }
 }


### PR DESCRIPTION
## 변경사항

- **식단 조회 기능 API 추가**:
  - 트레이니와 트레이너가 식단 목록을 조회할 수 있는 기능 추가.
  - 각 메서드에 주석 추가하여 이해하기 쉽게 개선.
- **식단 생성 기능 변경**:
  - 식단 생성 시 다수의 이미지 업로드에서 단일 이미지 업로드로 변경.
  - 서비스 메서드에 주석 추가.

### 관련 이슈 및 반영 브랜치

- **Issue**: #75 
- **Branch**: 
  - FROM: `feature/view-diet`
  - TO: `master`

---

## 설명

이번 변경사항은 다음과 같습니다:
1. 트레이니와 트레이너가 식단 목록을 조회할 수 있는 기능을 포함하고 있습니다. 식단 목록은 생성일 기준으로 내림차순 정렬되어 제공됩니다.
2. 식단 생성 시 다수의 이미지 업로드에서 단일 이미지 업로드로 변경하였습니다. 또한, 서비스 메서드에 주석을 추가하여 코드의 가독성을 높였습니다.

### ASIS

- 트레이니와 트레이너가 식단 목록을 조회할 수 있는 기능이 없었습니다.
- 식단 생성 시 여러 이미지를 업로드할 수 있었습니다.

### TOBE

- 트레이니와 트레이너는 식단 목록을 조회할 수 있습니다.
- 조회된 식단 목록은 생성일 기준으로 내림차순 정렬됩니다.
- 식단 생성 시 단일 이미지만 업로드할 수 있습니다.

### 테스트

- 식단 조회 API에 대한 유닛 테스트를 실행하여 올바르게 작동하는지 확인하였습니다.
- 식단 생성 시 단일 이미지 업로드가 올바르게 작동하는지 확인하였습니다.
- 수동 테스트를 통해 각 기능이 예상대로 작동하는지 확인하였습니다.

### 추가 테스트 시나리오

- 트레이니와 트레이너가 식단 목록을 조회할 수 있는지 확인.
- 잘못된 트레이니 ID로 조회 시 예외가 발생하는지 확인.
- 계약이 없는 트레이너가 식단 목록을 조회하려고 할 때 예외가 발생하는지 확인.
- 인증되지 않은 사용자가 식단 목록을 조회할 수 없는지 확인.
- 식단 생성 시 잘못된 이미지 파일 형식을 업로드하면 실패하는지 확인.
- 이미지 업로드 시 썸네일이 올바르게 생성되는지 확인.
- 이미지를 S3에 성공적으로 업로드하고 썸네일도 올바르게 저장되는지 확인.

### 참고 사항

- 새로운 API가 다른 서비스 및 구성 요소와 호환되는지 확인해야 합니다.
- 각 기능에 대한 추가 검증이 필요할 수 있습니다.

---

### API 문서

#### POST /api/diets/ - 식단 생성

```json
{
  "content": "오늘의 식단",
  "image": "data:image/jpeg;base64,..."
}
```

#### GET /api/diets/{id} - 식단 목록 조회

```json
{
  "content": [
    {
            "dietId": 12,
            "thumbnailUrl": "https://training-diary-bucket.s3.ap-northeast-2.amazonaws.com/thumb_c7a30c2b-f49a-497b-96c6-eab0ac98aac7.jpg"
        },
        {
            "dietId": 11,
            "thumbnailUrl": "https://training-diary-bucket.s3.ap-northeast-2.amazonaws.com/thumb_113f9b7c-d78f-41ae-91b9-15d51d8dd9e1.jpg"
        }
  ],
  "pageable": {
    "sort": {
      "sorted": true,
      "unsorted": false,
      "empty": false
    },
    "pageNumber": 0,
    "pageSize": 9,
    "offset": 0,
    "paged": true,
    "unpaged": false
  },
  "last": false,
  "totalPages": 1,
  "totalElements": 2,
  "size": 9,
  "number": 0,
  "sort": {
    "sorted": true,
    "unsorted": false,
    "empty": false
  },
  "first": true,
  "numberOfElements": 2,
  "empty": false
}
```

### 결론

이번 변경사항을 통해 트레이니와 트레이너가 식단 목록을 조회할 수 있는 기능을 구현하였습니다. 조회된 식단 목록은 생성일 기준으로 내림차순 정렬되어 제공되며, 이를 통해 시스템의 기능성과 사용자 편의성을 향상시켰습니다. 또한, 식단 생성 시 단일 이미지를 업로드하도록 변경하여 기능의 단순성과 일관성을 높였습니다. 새로운 API에 대한 자세한 내용은 위의 API 문서를 참고하시기 바랍니다.