### PR TITLE
이메일 인증 디자인 개선, 제목 및 유효시간까지 포함

### DIFF
--- a/src/main/java/com/project/trainingdiary/provider/EmailProvider.java
+++ b/src/main/java/com/project/trainingdiary/provider/EmailProvider.java
@@ -3,6 +3,7 @@ package com.project.trainingdiary.provider;
 import com.project.trainingdiary.exception.impl.EmailSendErrorException;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
+import java.io.UnsupportedEncodingException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -15,34 +16,40 @@ import org.springframework.stereotype.Component;
 public class EmailProvider {
 
   private final JavaMailSender javaMailSender;
-  private final String SUBJECT = "[트레이너 다이어리] 인증 매일입니다.";
+  private final String SUBJECT = "\uD83D\uDC4B 트다에 오신 것을 환영합니다! 이메일 인증을 완료해 주세요.";
 
-  public void sendVerificationEmail(String email, String verificationNumber) {
+  private static final String LOGO_IMAGE = "https://training-diary-brand.s3.ap-northeast-2.amazonaws.com/training_diary_logo_and_text.png";
+
+  public void sendVerificationEmail(String email, String verificationNumber, String expirationTime) {
     try {
       MimeMessage message = javaMailSender.createMimeMessage();
       MimeMessageHelper messageHelper = new MimeMessageHelper(message, true, "UTF-8");
 
-      String htmlContent = getVerificationMessage(verificationNumber);
+      String htmlContent = getVerificationMessage(verificationNumber, expirationTime);
 
+      messageHelper.setFrom("kyoominmir41@gmail.com", "Training Diary");
       messageHelper.setTo(email);
       messageHelper.setSubject(SUBJECT);
       messageHelper.setText(htmlContent, true);
       javaMailSender.send(message);
 
-    } catch (MessagingException e) {
-      log.error("Email 전송 실패 {}", e.getMessage());
+    } catch (MessagingException | UnsupportedEncodingException e) {
+      log.error("Email 전송 실패 {}", e.getMessage());
       throw new EmailSendErrorException();
     }
   }
 
-  private String getVerificationMessage(String verificationNumber) {
-
-    String verificationMessage = "";
-    verificationMessage += "<h1 style='text-align: center;'> [트레이너 다이어리] 인증매일</h1>";
-    verificationMessage +=
-        "<h3 style='text-align: center;'> 인증코드 : <strong style='font-size: 32px; letter-spacing: 8px;'>"
-            + verificationNumber + "</strong></h3>";
-
-    return verificationMessage;
+  private String getVerificationMessage(String verificationNumber, String expirationTime) {
+    return "<div style='font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; background-color: #FFFFFF; border: 1px solid #d3d3d3; border-radius: 10px;'>"
+        + "<div style='background-color: #62CEAD; padding: 20px; border-radius: 10px 10px 0 0; text-align: center;'>"
+        + "<img src='" + LOGO_IMAGE + "' alt='Training Diary Logo' style='width: 200px; height: auto;'/>"
+        + "</div>"
+        + "<div style='padding: 20px;'>"
+        + "<h2 style='text-align: center; color: #333;'>이메일 인증</h2>"
+        + "<p style='text-align: center; color: #555;'>다음 인증 코드를 사용하여 이메일 인증을 완료하세요:</p>"
+        + "<h1 style='text-align: center; font-size: 48px; color: #333;'>" + verificationNumber + "</h1>"
+        + "<p style='text-align: center; color: #777;'>이 인증코드는 <strong>" + expirationTime + "</strong> 까지 유효합니다.</p>"
+        + "</div>"
+        + "</div>";
   }
 }

--- a/src/main/java/com/project/trainingdiary/service/UserService.java
+++ b/src/main/java/com/project/trainingdiary/service/UserService.java
@@ -31,6 +31,8 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
@@ -155,7 +157,9 @@ public class UserService implements UserDetailsService {
    */
   private void sendVerificationCode(String email) {
     String verificationCode = VerificationCodeGeneratorUtil.generateVerificationCode();
-    emailProvider.sendVerificationEmail(email, verificationCode);
+    String expirationTime = VerificationCodeGeneratorUtil.generateExpirationTime();
+
+    emailProvider.sendVerificationEmail(email, verificationCode, expirationTime);
     verificationRepository.save(VerificationEntity.of(email, verificationCode));
   }
 

--- a/src/main/java/com/project/trainingdiary/util/VerificationCodeGeneratorUtil.java
+++ b/src/main/java/com/project/trainingdiary/util/VerificationCodeGeneratorUtil.java
@@ -1,5 +1,9 @@
 package com.project.trainingdiary.util;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
 public class VerificationCodeGeneratorUtil {
 
   public static String generateVerificationCode() {
@@ -10,5 +14,11 @@ public class VerificationCodeGeneratorUtil {
       verificationCode.append((int) (Math.random() * 10));
     }
     return verificationCode.toString();
+  }
+
+  public static String generateExpirationTime() {
+    LocalDateTime expirationDateTime = LocalDateTime.now(ZoneId.of("Asia/Seoul")).plusMinutes(10);
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+    return expirationDateTime.format(formatter);
   }
 }


### PR DESCRIPTION
## 변경사항

- **이메일 제공자 디자인 개선**:
  - 이메일에 로고 추가.
  - 제목 변경.
  - 이메일 디자인 변경.
  - 이메일에 만료 시간 추가.

### 관련 이슈 및 반영 브랜치

- **Issue**: #58 
- **Branch**: 
  - FROM: `enhancement/mail-format`
  - TO: `master`

---

## 설명

이번 변경사항은 이메일 제공자의 디자인을 개선하기 위한 것입니다. 이메일에 로고를 추가하고, 제목을 변경하였으며, 이메일의 디자인을 변경하여 만료 시간을 포함하도록 하였습니다.

### ASIS

- 기존 이메일 디자인은 로고가 없었고, 제목이 단순하며, 만료 시간을 포함하지 않았습니다.

### TOBE

- 이메일에 로고가 포함됩니다.
- 이메일 제목이 변경됩니다.
- 이메일 디자인이 개선되어 만료 시간이 포함됩니다.

### 예시 이미지

아래는 개선된 이메일 디자인의 예시입니다:
<img width="688" alt="Screenshot 2024-07-20 at 1 55 59 AM" src="https://github.com/user-attachments/assets/fb32cd43-0612-48fd-a222-8d24355f8f95">

### 결론

이번 변경사항을 통해 이메일 제공자의 디자인을 개선하였습니다. 이메일에 로고를 추가하고, 제목을 변경하였으며, 이메일의 디자인을 변경하여 만료 시간을 포함하도록 하였습니다. 이를 통해 시스템의 기능성과 사용자 경험을 향상시켰습니다.
