### PR TITLE
식단 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/project/trainingdiary/controller/DietController.java
+++ b/src/main/java/com/project/trainingdiary/controller/DietController.java
@@ -1,6 +1,7 @@
 package com.project.trainingdiary.controller;
 
 import com.project.trainingdiary.dto.request.CreateDietRequestDto;
+import com.project.trainingdiary.dto.response.DietDetailsInfoResponseDto;
 import com.project.trainingdiary.dto.response.DietImageResponseDto;
 import com.project.trainingdiary.service.DietService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -54,8 +55,14 @@ public class DietController {
     return ResponseEntity.ok().build();
   }
 
-  @Operation(summary = "식단 목록 조회", description = "트레이니의 식단 목록을 페이징하여 조회합니다.")
+  @Operation(
+      summary = "식단 목록 조회",
+      description = "트레이니의 식단 목록을 페이징하여 조회합니다."
+  )
   @GetMapping("{id}")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "성공"),
+  })
   public ResponseEntity<Page<DietImageResponseDto>> getTraineeDiets(
       @PathVariable Long id,
       @RequestParam(defaultValue = "0") int page,
@@ -66,5 +73,20 @@ public class DietController {
     Page<DietImageResponseDto> diets = dietService.getDiets(id, pageable);
 
     return ResponseEntity.ok(diets);
+  }
+
+  @Operation(
+      summary = "식단 상세",
+      description = "식단의 상세을 표시합니다."
+  )
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "성공"),
+  })
+  @GetMapping("{id}/details")
+  public ResponseEntity<DietDetailsInfoResponseDto> getDietDetails(
+      @PathVariable Long id
+  ) {
+    DietDetailsInfoResponseDto diet = dietService.getDietDetails(id);
+    return ResponseEntity.ok(diet);
   }
 }

--- a/src/main/java/com/project/trainingdiary/dto/response/DietDetailsInfoResponseDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/response/DietDetailsInfoResponseDto.java
@@ -1,0 +1,25 @@
+package com.project.trainingdiary.dto.response;
+
+import com.project.trainingdiary.entity.DietEntity;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DietDetailsInfoResponseDto {
+
+  private Long id;
+  private String imageUrl;
+  private String content;
+  private LocalDateTime createdDate;
+
+  public static DietDetailsInfoResponseDto of(DietEntity diet) {
+    return DietDetailsInfoResponseDto.builder()
+        .id(diet.getId())
+        .imageUrl(diet.getOriginalUrl())
+        .content(diet.getContent())
+        .createdDate(diet.getCreatedAt())
+        .build();
+  }
+}

--- a/src/main/java/com/project/trainingdiary/exception/impl/DietNotExistException.java
+++ b/src/main/java/com/project/trainingdiary/exception/impl/DietNotExistException.java
@@ -1,0 +1,11 @@
+package com.project.trainingdiary.exception.impl;
+
+import com.project.trainingdiary.exception.GlobalException;
+import org.springframework.http.HttpStatus;
+
+public class DietNotExistException extends GlobalException {
+
+  public DietNotExistException() {
+    super(HttpStatus.NOT_FOUND, "해당 식단을 찾을 수 없습니다.");
+  }
+}

--- a/src/main/java/com/project/trainingdiary/provider/EmailProvider.java
+++ b/src/main/java/com/project/trainingdiary/provider/EmailProvider.java
@@ -20,7 +20,8 @@ public class EmailProvider {
 
   private static final String LOGO_IMAGE = "https://training-diary-brand.s3.ap-northeast-2.amazonaws.com/training_diary_logo_and_text.png";
 
-  public void sendVerificationEmail(String email, String verificationNumber, String expirationTime) {
+  public void sendVerificationEmail(String email, String verificationNumber,
+      String expirationTime) {
     try {
       MimeMessage message = javaMailSender.createMimeMessage();
       MimeMessageHelper messageHelper = new MimeMessageHelper(message, true, "UTF-8");
@@ -40,16 +41,20 @@ public class EmailProvider {
   }
 
   private String getVerificationMessage(String verificationNumber, String expirationTime) {
-    return "<div style='font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; background-color: #FFFFFF; border: 1px solid #d3d3d3; border-radius: 10px;'>"
-        + "<div style='background-color: #62CEAD; padding: 20px; border-radius: 10px 10px 0 0; text-align: center;'>"
-        + "<img src='" + LOGO_IMAGE + "' alt='Training Diary Logo' style='width: 200px; height: auto;'/>"
-        + "</div>"
-        + "<div style='padding: 20px;'>"
-        + "<h2 style='text-align: center; color: #333;'>이메일 인증</h2>"
-        + "<p style='text-align: center; color: #555;'>다음 인증 코드를 사용하여 이메일 인증을 완료하세요:</p>"
-        + "<h1 style='text-align: center; font-size: 48px; color: #333;'>" + verificationNumber + "</h1>"
-        + "<p style='text-align: center; color: #777;'>이 인증코드는 <strong>" + expirationTime + "</strong> 까지 유효합니다.</p>"
-        + "</div>"
-        + "</div>";
+    return
+        "<div style='font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; background-color: #FFFFFF; border: 1px solid #d3d3d3; border-radius: 10px;'>"
+            + "<div style='background-color: #62CEAD; padding: 20px; border-radius: 10px 10px 0 0; text-align: center;'>"
+            + "<img src='" + LOGO_IMAGE
+            + "' alt='Training Diary Logo' style='width: 200px; height: auto;'/>"
+            + "</div>"
+            + "<div style='padding: 20px;'>"
+            + "<h2 style='text-align: center; color: #333;'>이메일 인증</h2>"
+            + "<p style='text-align: center; color: #555;'>다음 인증 코드를 사용하여 이메일 인증을 완료하세요:</p>"
+            + "<h1 style='text-align: center; font-size: 48px; color: #333;'>" + verificationNumber
+            + "</h1>"
+            + "<p style='text-align: center; color: #777;'>이 인증코드는 <strong>" + expirationTime
+            + "</strong> 까지 유효합니다.</p>"
+            + "</div>"
+            + "</div>";
   }
 }

--- a/src/main/java/com/project/trainingdiary/repository/DietRepository.java
+++ b/src/main/java/com/project/trainingdiary/repository/DietRepository.java
@@ -1,6 +1,7 @@
 package com.project.trainingdiary.repository;
 
 import com.project.trainingdiary.entity.DietEntity;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,4 +9,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface DietRepository extends JpaRepository<DietEntity, Long> {
 
   Page<DietEntity> findByTraineeId(Long traineeId, Pageable pageable);
+
+  Optional<DietEntity> findByTraineeIdAndId(Long id, Long id1);
 }

--- a/src/main/java/com/project/trainingdiary/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/project/trainingdiary/security/JwtAuthenticationFilter.java
@@ -121,7 +121,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
           userDetails, null, userDetails.getAuthorities());
       authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
       SecurityContextHolder.getContext().setAuthentication(authentication);
-      log.info("사용자가 인증되었습니다: {}", username);
+      log.info("사용자: {} Role: {}", username, authentication.getAuthorities().toString());
     }
   }
 

--- a/src/main/java/com/project/trainingdiary/service/UserService.java
+++ b/src/main/java/com/project/trainingdiary/service/UserService.java
@@ -31,8 +31,6 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;

--- a/src/test/java/com/project/trainingdiary/service/UserServiceTest.java
+++ b/src/test/java/com/project/trainingdiary/service/UserServiceTest.java
@@ -143,12 +143,14 @@ public class UserServiceTest {
     when(traineeRepository.findByEmail(sendDto.getEmail())).thenReturn(Optional.empty());
     when(trainerRepository.findByEmail(sendDto.getEmail())).thenReturn(Optional.empty());
 
-    doNothing().when(emailProvider).sendVerificationEmail(eq(sendDto.getEmail()), anyString());
+    doNothing().when(emailProvider)
+        .sendVerificationEmail(eq(sendDto.getEmail()), anyString(), anyString());
 
     userService.checkDuplicateEmailAndSendVerification(sendDto);
 
     verify(verificationRepository, times(1)).save(verificationEntityCaptor.capture());
-    verify(emailProvider, times(1)).sendVerificationEmail(eq(sendDto.getEmail()), anyString());
+    verify(emailProvider, times(1)).sendVerificationEmail(eq(sendDto.getEmail()), anyString(),
+        anyString());
 
     VerificationEntity capturedVerificationEntity = verificationEntityCaptor.getValue();
     assertNotNull(capturedVerificationEntity.getVerificationCode());


### PR DESCRIPTION
### 변경사항

- **식단 상세 조회 API 추가**:
  - 트레이니와 트레이너가 식단 상세 정보를 조회할 수 있는 기능 추가.
  - 각 메서드에 주석 추가하여 이해하기 쉽게 개선.
  - 트레이너의 경우, 조회하려는 식단이 계약된 트레이니의 것인지 확인하는 로직 추가.

### 관련 이슈 및 반영 브랜치

- **Issue** : #84 

- **Branch:**
  - FROM: `feature/diet-details-view`
  - TO: `master`

---

## 설명

이번 변경사항은 트레이니와 트레이너가 식단 상세 정보를 조회할 수 있는 기능을 포함하고 있습니다. 트레이너의 경우, 조회하려는 식단이 계약된 트레이니의 것인지 확인하는 로직이 추가되었습니다. 또한, 각 메서드에 주석을 추가하여 이해하기 쉽게 개선하였습니다.

### ASIS

- 트레이니와 트레이너가 식단 상세 정보를 조회할 수 있는 기능이 없었습니다.

### TOBE

- 트레이니와 트레이너는 식단 상세 정보를 조회할 수 있습니다.
- 트레이너는 조회하려는 식단이 계약된 트레이니의 것인지 확인할 수 있습니다.
- 트레이니는 본인의 식단만 조회할 수 있습니다.

### 테스트

- 식단 상세 조회 API에 대한 유닛 테스트를 실행하여 올바르게 작동하는지 확인하였습니다.
- 수동 테스트를 통해 각 기능이 예상대로 작동하는지 확인하였습니다.

### 추가 테스트 시나리오

- 잘못된 트레이니 ID로 조회 시 예외가 발생하는지 확인.
- 계약이 없는 트레이너가 식단 상세 정보를 조회하려고 할 때 예외가 발생하는지 확인.
- 인증되지 않은 사용자가 식단 상세 정보를 조회할 수 없는지 확인.
- 트레이니가 다른 트레이니의 식단을 조회할 수 없는지 확인.
- 트레이니가 본인의 식단을 올바르게 조회할 수 있는지 확인.
- 트레이너가 계약된 트레이니의 식단을 올바르게 조회할 수 있는지 확인.

### 참고 사항

- 새로운 API가 다른 서비스 및 구성 요소와 호환되는지 확인해야 합니다.
- 각 기능에 대한 추가 검증이 필요할 수 있습니다.

---

### API 문서

#### GET /api/diets/{id}/details - 식단 상세 조회

```json
{
  "id": 1,
  "imageUrl": "https://test-bucket.s3.amazonaws.com/diet1.jpg",
  "content": "오늘의 식단 내용",
  "createdDate": "2024-07-20T02:24:00Z"
}
```

### 결론

이번 변경사항을 통해 트레이니와 트레이너가 식단 상세 정보를 조회할 수 있는 기능을 구현하였습니다. 트레이너는 조회하려는 식단이 계약된 트레이니의 것인지 확인할 수 있으며, 트레이니는 본인의 식단만 조회할 수 있습니다. 이를 통해 시스템의 기능성과 보안성을 향상시켰습니다.