### PR TITLE
트레이니의 식단 삭제 API 구현

### DIFF
--- a/src/main/java/com/project/trainingdiary/controller/DietController.java
+++ b/src/main/java/com/project/trainingdiary/controller/DietController.java
@@ -17,6 +17,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -88,5 +89,19 @@ public class DietController {
   ) {
     DietDetailsInfoResponseDto diet = dietService.getDietDetails(id);
     return ResponseEntity.ok(diet);
+  }
+
+  @Operation(
+      summary = "트레이니의 식단 삭제",
+      description = "트레이니의 식단을 삭제합니다."
+  )
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "성공"),
+  })
+  @PreAuthorize("hasRole('TRAINEE')")
+  @DeleteMapping("{id}")
+  public ResponseEntity<Void> deleteDiet(@PathVariable Long id) {
+    dietService.deleteDiet(id);
+    return ResponseEntity.ok().build();
   }
 }

--- a/src/main/java/com/project/trainingdiary/service/DietService.java
+++ b/src/main/java/com/project/trainingdiary/service/DietService.java
@@ -187,12 +187,16 @@ public class DietService {
    * @param id 식단 ID
    * @throws DietNotExistException 식단이 존재하지 않을 위해 예외 발생
    */
+  @Transactional
   public void deleteDiet(Long id) {
 
     TraineeEntity trainee = getAuthenticatedTrainee();
 
     DietEntity diet = dietRepository.findByTraineeIdAndId(trainee.getId(), id)
         .orElseThrow(DietNotExistException::new);
+
+    imageUtil.deleteFileFromS3(diet.getOriginalUrl());
+    imageUtil.deleteFileFromS3(diet.getThumbnailUrl());
 
     dietRepository.delete(diet);
   }

--- a/src/main/java/com/project/trainingdiary/service/DietService.java
+++ b/src/main/java/com/project/trainingdiary/service/DietService.java
@@ -182,6 +182,22 @@ public class DietService {
   }
 
   /**
+   * 트레이니의 식단을 삭제합니다.
+   *
+   * @param id 식단 ID
+   * @throws DietNotExistException 식단이 존재하지 않을 위해 예외 발생
+   */
+  public void deleteDiet(Long id) {
+
+    TraineeEntity trainee = getAuthenticatedTrainee();
+
+    DietEntity diet = dietRepository.findByTraineeIdAndId(trainee.getId(), id)
+        .orElseThrow(DietNotExistException::new);
+
+    dietRepository.delete(diet);
+  }
+
+  /**
    * 트레이너가 트레이니와 계약을 맺고 있는지 확인합니다.
    *
    * @param trainer 트레이너 엔티티

--- a/src/main/java/com/project/trainingdiary/util/ImageUtil.java
+++ b/src/main/java/com/project/trainingdiary/util/ImageUtil.java
@@ -81,4 +81,14 @@ public class ImageUtil {
     }
     return MediaType.APPLICATION_OCTET_STREAM_VALUE;
   }
+
+  /**
+   * S3에서 파일을 삭제합니다.
+   *
+   * @param fileUrl 삭제할 파일의 URL
+   */
+  public void deleteFileFromS3(String fileUrl) {
+    String fileKey = fileUrl.substring(fileUrl.lastIndexOf("/") + 1);
+    s3Operations.deleteObject(bucket, fileKey);
+  }
 }


### PR DESCRIPTION
### 변경사항

- **트레이니의 식단 삭제 API 추가**:
  - 트레이니가 본인의 식단을 삭제할 수 있는 기능 추가.
  - 각 메서드에 주석 추가하여 이해하기 쉽게 개선.

### 관련 이슈 및 반영 브랜치

- **Issue** : #87   

- **Branch:**
  - FROM: `feature/delete-diet-trainee`
  - TO: `master`

---

## 설명

이번 변경사항은 트레이니가 본인의 식단을 삭제할 수 있는 기능을 포함하고 있습니다. 각 메서드에 주석을 추가하여 이해하기 쉽게 개선하였습니다.

### ASIS

- 트레이니가 본인의 식단을 삭제할 수 있는 기능이 없었습니다.

### TOBE

- 트레이니는 본인의 식단을 삭제할 수 있습니다.

### 테스트

- 식단 삭제 API에 대한 유닛 테스트를 실행하여 올바르게 작동하는지 확인하였습니다.
- 수동 테스트를 통해 각 기능이 예상대로 작동하는지 확인하였습니다.

### 추가 테스트 시나리오

- 잘못된 트레이니 ID로 삭제 시 예외가 발생하는지 확인.
- 인증되지 않은 사용자가 식단을 삭제할 수 없는지 확인.
- 트레이니가 다른 트레이니의 식단을 삭제할 수 없는지 확인.
- 트레이니가 본인의 식단을 올바르게 삭제할 수 있는지 확인.

### 참고 사항

- 새로운 API가 다른 서비스 및 구성 요소와 호환되는지 확인해야 합니다.
- 각 기능에 대한 추가 검증이 필요할 수 있습니다.

---

### API 문서

#### DELETE /api/diets/{id} - 식단 삭제
200 OK

### 결론

이번 변경사항을 통해 트레이니가 본인의 식단을 삭제할 수 있는 기능을 구현하였습니다. 이를 통해 시스템의 기능성과 사용자 편의성을 향상시켰습니다.