### PR TITLE
읽지 않은 메시지 표시 필드 관리

### DIFF
--- a/src/main/java/com/project/trainingdiary/dto/response/MemberInfoResponseDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/response/MemberInfoResponseDto.java
@@ -12,4 +12,5 @@ public class MemberInfoResponseDto {
   private String email;
   private String name;
   private UserRoleType role;
+  private boolean unreadNotification;
 }

--- a/src/main/java/com/project/trainingdiary/entity/TraineeEntity.java
+++ b/src/main/java/com/project/trainingdiary/entity/TraineeEntity.java
@@ -72,4 +72,6 @@ public class TraineeEntity extends BaseEntity {
 
   @OneToOne(mappedBy = "trainee")
   private FcmTokenEntity fcmToken;
+
+  private boolean unreadNotification;
 }

--- a/src/main/java/com/project/trainingdiary/entity/TrainerEntity.java
+++ b/src/main/java/com/project/trainingdiary/entity/TrainerEntity.java
@@ -46,4 +46,6 @@ public class TrainerEntity extends BaseEntity {
 
   @OneToOne(mappedBy = "trainer")
   private FcmTokenEntity fcmToken;
+
+  private boolean unreadNotification;
 }

--- a/src/main/java/com/project/trainingdiary/service/NotificationService.java
+++ b/src/main/java/com/project/trainingdiary/service/NotificationService.java
@@ -26,11 +26,17 @@ public class NotificationService {
   public Page<NotificationResponseDto> getNotificationList(Pageable pageable) {
     switch (getMyRole()) {
       case TRAINEE -> {
-        return notificationRepository.findByTrainee_Id(getTrainee().getId(), pageable)
+        TraineeEntity trainee = getTrainee();
+        trainee.setUnreadNotification(false);
+        traineeRepository.save(trainee);
+        return notificationRepository.findByTrainee_Id(trainee.getId(), pageable)
             .map(NotificationResponseDto::fromEntity);
       }
       case TRAINER -> {
-        return notificationRepository.findByTrainer_Id(getTrainer().getId(), pageable)
+        TrainerEntity trainer = getTrainer();
+        trainer.setUnreadNotification(false);
+        trainerRepository.save(trainer);
+        return notificationRepository.findByTrainer_Id(trainer.getId(), pageable)
             .map(NotificationResponseDto::fromEntity);
       }
       default -> throw new UserNotFoundException();

--- a/src/main/java/com/project/trainingdiary/service/ScheduleTraineeService.java
+++ b/src/main/java/com/project/trainingdiary/service/ScheduleTraineeService.java
@@ -96,6 +96,7 @@ public class ScheduleTraineeService {
     );
     notificationRepository.save(notification);
     fcmPushNotification.sendPushNotification(notification);
+    schedule.getTrainer().setUnreadNotification(true);
 
     return new ApplyScheduleResponseDto(schedule.getId(), schedule.getScheduleStatus());
   }

--- a/src/main/java/com/project/trainingdiary/service/UserService.java
+++ b/src/main/java/com/project/trainingdiary/service/UserService.java
@@ -380,6 +380,7 @@ public class UserService implements UserDetailsService {
               .email(trainer.getEmail())
               .name(trainer.getName())
               .role(trainer.getRole())
+              .unreadNotification(trainer.isUnreadNotification())
               .build())
           .orElseThrow(TrainerNotFoundException::new);
     }
@@ -389,6 +390,7 @@ public class UserService implements UserDetailsService {
             .email(trainee.getEmail())
             .name(trainee.getName())
             .role(trainee.getRole())
+            .unreadNotification(trainee.isUnreadNotification())
             .build())
         .orElseThrow(TrainerNotFoundException::new);
   }


### PR DESCRIPTION
### 변경사항

<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요 -->
**AS-IS**
- 사용자가 읽을 메시지가 있는지 표시하는 필드가 필요

**TO-BE**
- 트레이너와 트레이니와 읽을 메시지가 있는지 표시하는 필드 추가
- 알림 목록 조회 시 해당 필드를 false로 수정
- 트레이니의 일정 예약 신청 시 트레이너의 해당 필드를 true로 수정

### 테스트

<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 

- [x] 테스트 코드
  - 알림 조회 시 읽을 메시지가 더 있다는 표시가 수정되는지 확인
- [x] API 테스트
  - GET api/user/info
  - 응답 예시
```json
{
  "id": 1,
  "email": "hello@example.com",
  "name": "이삼사",
  "role": "TRAINER",
  "unreadNotification": false
}
```

Resolves #93 