### PR TITLE
배포전에 필요한 CORS 설정 추가

### DIFF
--- a/src/main/java/com/project/trainingdiary/security/SecurityConfig.java
+++ b/src/main/java/com/project/trainingdiary/security/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.project.trainingdiary.security;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
@@ -15,6 +16,9 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
@@ -24,27 +28,40 @@ public class SecurityConfig {
 
   private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
+  private static final long MAX_AGE_SECS = 3600L;
+
   @Bean
   public SecurityFilterChain configure(HttpSecurity http) throws Exception {
 
     http
         .csrf(AbstractHttpConfigurer::disable)
-//        .sessionManagement(e -> e.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .httpBasic(AbstractHttpConfigurer::disable)
         .authorizeHttpRequests(authz -> authz
             .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html",
                 "/swagger-resources/**", "/webjars/**", "/h2-console/**", "api/users/**")
-            .permitAll() // Swagger UI
-            .requestMatchers("/api/pt-contracts/**").authenticated()
-            .requestMatchers("/api/schedules/**").authenticated()
-            .requestMatchers("/api/workout-types/**").authenticated()
-            .requestMatchers("api/workout-sessions", "api/workout-sessions/**").authenticated()
+            .permitAll()
             .anyRequest().authenticated())
         .exceptionHandling(exception -> exception
             .authenticationEntryPoint(new FailedAuthenticationEntryPoint()))
         .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
     return http.build();
+  }
+
+  @Bean
+  protected CorsConfigurationSource corsConfigurationSource() {
+
+    CorsConfiguration configuration = new CorsConfiguration();
+    configuration.setAllowedHeaders(List.of("Cache-Control", "Content-Type", "Cookie"));
+    configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE"));
+    configuration.setAllowedOrigins(List.of("*"));
+    configuration.setAllowCredentials(true);
+    configuration.setMaxAge(MAX_AGE_SECS);
+
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", configuration);
+
+    return source;
   }
 }
 


### PR DESCRIPTION
### 변경사항

- **CORS 설정 추가**:
  - CORS 설정을 추가하여 클라이언트와 서버 간의 원활한 통신을 보장.
  - 허용 헤더, 메서드, 출처 및 자격 증명 설정 포함.

### 관련 이슈 및 반영 브랜치

- **Issue**: #97  
- **Branch**: 
  - FROM: `feature/cors-configuration`
  - TO: `master`

---

## 설명

이번 변경사항은 서버의 CORS 설정을 추가하여 클라이언트와 서버 간의 원활한 통신을 보장하는 것입니다. CORS 설정을 통해 허용 헤더, 메서드, 출처 및 자격 증명 설정을 추가하였습니다.

### ASIS

- 기존에는 CORS 설정이 없어 클라이언트와 서버 간의 통신이 원활하지 않았습니다.

### TOBE

- 허용 헤더: `Cache-Control`, `Content-Type`, `Cookie`
- 허용 메서드: `GET`, `POST`, `PUT`, `DELETE`
- 허용 출처: 모든 출처 (`*`) **(배포 될시 수정 예정)**
- 자격 증명 허용: `true`
- 최대 허용 시간: `MAX_AGE_SECS`

### 테스트

- 수동 테스트를 통해 각 기능이 예상대로 작동하는지 확인하였습니다.

### 추가 테스트 시나리오

- 클라이언트에서 다양한 메서드(`GET`, `POST`, `PUT`, `DELETE`)를 사용하여 서버에 요청을 보내고 올바르게 처리되는지 확인.
- 클라이언트에서 다양한 헤더(`Cache-Control`, `Content-Type`, `Cookie`)를 포함하여 요청을 보내고 올바르게 처리되는지 확인.
- 자격 증명을 포함한 요청이 올바르게 처리되는지 확인.
- 다른 출처에서의 요청이 올바르게 처리되는지 확인.

### 참고 사항

- 새로운 CORS 설정이 다른 서비스 및 구성 요소와 호환되는지 확인해야 합니다.
- 각 기능에 대한 추가 검증이 필요할 수 있습니다.

---

### 코드

```java
@Bean
protected CorsConfigurationSource corsConfigurationSource() {

  CorsConfiguration configuration = new CorsConfiguration();
  configuration.setAllowedHeaders(List.of("Cache-Control", "Content-Type", "Cookie"));
  configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE"));
  configuration.setAllowedOrigins(List.of("*"));
  configuration.setAllowCredentials(true);
  configuration.setMaxAge(MAX_AGE_SECS);

  UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
  source.registerCorsConfiguration("/**", configuration);

  return source;
}
```

### 결론

이번 변경사항을 통해 서버의 CORS 설정을 추가하여 클라이언트와 서버 간의 원활한 통신을 보장하였습니다. 허용 헤더, 메서드, 출처 및 자격 증명 설정을 추가하여 보안성과 기능성을 향상시켰습니다.