### PR TITLE
트레이너 댓글 API 셋팅, 식단 상세정보에 댓글 필드 추가 구현

### DIFF
--- a/src/main/java/com/project/trainingdiary/controller/DietController.java
+++ b/src/main/java/com/project/trainingdiary/controller/DietController.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -43,7 +44,7 @@ public class DietController {
       @ApiResponse(responseCode = "200", description = "성공"),
   })
   @PreAuthorize("hasRole('TRAINEE')")
-  @PostMapping
+  @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   public ResponseEntity<Void> createDiet(
       @RequestPart("image") MultipartFile image,
       @RequestPart("content") String content

--- a/src/main/java/com/project/trainingdiary/controller/TrainerCommentController.java
+++ b/src/main/java/com/project/trainingdiary/controller/TrainerCommentController.java
@@ -1,0 +1,34 @@
+package com.project.trainingdiary.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "8 - Trainer Comment API", description = "트레이너의 식단 댓글 관리 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/trainer-comments/")
+public class TrainerCommentController {
+
+  @PostMapping
+  public ResponseEntity<Void> createTrainerComment() {
+    return ResponseEntity.ok().build();
+  }
+
+  @PutMapping
+  public ResponseEntity<Void> updateTrainerComment() {
+    return ResponseEntity.ok().build();
+  }
+
+  @PostMapping("{id}")
+  public ResponseEntity<Void> deleteTrainerComment(
+      @PathVariable Long id
+  ) {
+    return ResponseEntity.ok().build();
+  }
+}

--- a/src/main/java/com/project/trainingdiary/dto/request/diet/CreateDietRequestDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/request/diet/CreateDietRequestDto.java
@@ -1,5 +1,7 @@
 package com.project.trainingdiary.dto.request.diet;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.web.multipart.MultipartFile;
@@ -8,6 +10,11 @@ import org.springframework.web.multipart.MultipartFile;
 @Builder
 public class CreateDietRequestDto {
 
+  @Schema(example = "6월 27일 오늘 점심 식단입니다!")
+  @NotNull(message = "content을 입력하세요")
   private String content;
+
+  @Schema(example = "image1.png")
+  @NotNull(message = "image를 업로드하세요.")
   private MultipartFile image;
 }

--- a/src/main/java/com/project/trainingdiary/dto/response/diet/DietDetailsInfoResponseDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/response/diet/DietDetailsInfoResponseDto.java
@@ -1,7 +1,9 @@
 package com.project.trainingdiary.dto.response.diet;
 
 import com.project.trainingdiary.entity.DietEntity;
+import com.project.trainingdiary.entity.TrainerCommentEntity;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -12,13 +14,16 @@ public class DietDetailsInfoResponseDto {
   private Long id;
   private String imageUrl;
   private String content;
+  private List<String> trainerComments;
   private LocalDateTime createdDate;
 
-  public static DietDetailsInfoResponseDto of(DietEntity diet) {
+  public static DietDetailsInfoResponseDto of(DietEntity diet,
+      List<TrainerCommentEntity> trainerComment) {
     return DietDetailsInfoResponseDto.builder()
         .id(diet.getId())
         .imageUrl(diet.getOriginalUrl())
         .content(diet.getContent())
+        .trainerComments(trainerComment.stream().map(TrainerCommentEntity::getComment).toList())
         .createdDate(diet.getCreatedAt())
         .build();
   }

--- a/src/main/java/com/project/trainingdiary/dto/response/diet/DietDetailsInfoResponseDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/response/diet/DietDetailsInfoResponseDto.java
@@ -14,7 +14,7 @@ public class DietDetailsInfoResponseDto {
   private Long id;
   private String imageUrl;
   private String content;
-  private List<String> trainerComments;
+  private List<TrainerCommentEntity> trainerComments;
   private LocalDateTime createdDate;
 
   public static DietDetailsInfoResponseDto of(DietEntity diet,
@@ -23,7 +23,7 @@ public class DietDetailsInfoResponseDto {
         .id(diet.getId())
         .imageUrl(diet.getOriginalUrl())
         .content(diet.getContent())
-        .trainerComments(trainerComment.stream().map(TrainerCommentEntity::getComment).toList())
+        .trainerComments(trainerComment)
         .createdDate(diet.getCreatedAt())
         .build();
   }

--- a/src/main/java/com/project/trainingdiary/entity/DietEntity.java
+++ b/src/main/java/com/project/trainingdiary/entity/DietEntity.java
@@ -9,6 +9,8 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -32,4 +34,7 @@ public class DietEntity extends BaseEntity {
   @ManyToOne(fetch = LAZY)
   @JoinColumn(name = "trainee_id")
   private TraineeEntity trainee;
+
+  @OneToMany(mappedBy = "diet", fetch = LAZY)
+  private List<TrainerCommentEntity> comments;
 }

--- a/src/main/java/com/project/trainingdiary/entity/TrainerCommentEntity.java
+++ b/src/main/java/com/project/trainingdiary/entity/TrainerCommentEntity.java
@@ -1,0 +1,39 @@
+package com.project.trainingdiary.entity;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity(name = "trainer_comment")
+public class TrainerCommentEntity extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = IDENTITY)
+  private Long id;
+
+  private String comment;
+
+  @ManyToOne
+  @JoinColumn(name = "trainer_id")
+  private TrainerEntity trainer;
+
+  @ManyToOne(fetch = LAZY)
+  @JoinColumn(name = "diet_id")
+  private DietEntity diet;
+}

--- a/src/main/java/com/project/trainingdiary/entity/TrainerCommentEntity.java
+++ b/src/main/java/com/project/trainingdiary/entity/TrainerCommentEntity.java
@@ -14,7 +14,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-
 @Getter
 @Setter
 @NoArgsConstructor

--- a/src/main/java/com/project/trainingdiary/exception/trainer/TrainerCommentNotExistException.java
+++ b/src/main/java/com/project/trainingdiary/exception/trainer/TrainerCommentNotExistException.java
@@ -1,0 +1,11 @@
+package com.project.trainingdiary.exception.trainer;
+
+import com.project.trainingdiary.exception.GlobalException;
+import org.springframework.http.HttpStatus;
+
+public class TrainerCommentNotExistException extends GlobalException {
+
+  public TrainerCommentNotExistException() {
+    super(HttpStatus.NOT_FOUND, "트레이너의 식단 댓글이 없습니다.");
+  }
+}

--- a/src/main/java/com/project/trainingdiary/repository/TrainerCommentRepository.java
+++ b/src/main/java/com/project/trainingdiary/repository/TrainerCommentRepository.java
@@ -1,0 +1,11 @@
+package com.project.trainingdiary.repository;
+
+import com.project.trainingdiary.entity.TrainerCommentEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TrainerCommentRepository extends JpaRepository<TrainerCommentEntity, Long> {
+
+  List<TrainerCommentEntity> findByDietId(Long id);
+
+}

--- a/src/main/java/com/project/trainingdiary/service/DietService.java
+++ b/src/main/java/com/project/trainingdiary/service/DietService.java
@@ -5,6 +5,7 @@ import com.project.trainingdiary.dto.response.diet.DietDetailsInfoResponseDto;
 import com.project.trainingdiary.dto.response.diet.DietImageResponseDto;
 import com.project.trainingdiary.entity.DietEntity;
 import com.project.trainingdiary.entity.TraineeEntity;
+import com.project.trainingdiary.entity.TrainerCommentEntity;
 import com.project.trainingdiary.entity.TrainerEntity;
 import com.project.trainingdiary.exception.diet.DietNotExistException;
 import com.project.trainingdiary.exception.ptcontract.PtContractNotExistException;
@@ -15,10 +16,12 @@ import com.project.trainingdiary.exception.workout.InvalidFileTypeException;
 import com.project.trainingdiary.model.type.UserRoleType;
 import com.project.trainingdiary.repository.DietRepository;
 import com.project.trainingdiary.repository.TraineeRepository;
+import com.project.trainingdiary.repository.TrainerCommentRepository;
 import com.project.trainingdiary.repository.TrainerRepository;
 import com.project.trainingdiary.repository.ptContract.PtContractRepository;
 import com.project.trainingdiary.util.ImageUtil;
 import java.io.IOException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -38,6 +41,8 @@ public class DietService {
   private final TraineeRepository traineeRepository;
   private final TrainerRepository trainerRepository;
   private final PtContractRepository ptContractRepository;
+  private final TrainerCommentRepository trainerCommentRepository;
+
   private final ImageUtil imageUtil;
 
   /**
@@ -160,7 +165,9 @@ public class DietService {
     DietEntity diet = dietRepository.findByTraineeIdAndId(trainee.getId(), id)
         .orElseThrow(DietNotExistException::new);
 
-    return DietDetailsInfoResponseDto.of(diet);
+    List<TrainerCommentEntity> trainerCommentEntities = trainerCommentRepository.findByDietId(id);
+
+    return DietDetailsInfoResponseDto.of(diet, trainerCommentEntities);
   }
 
   /**
@@ -178,7 +185,9 @@ public class DietService {
 
     hasContractWithTrainee(trainer, diet.getTrainee());
 
-    return DietDetailsInfoResponseDto.of(diet);
+    List<TrainerCommentEntity> trainerCommentEntities = trainerCommentRepository.findByDietId(id);
+
+    return DietDetailsInfoResponseDto.of(diet, trainerCommentEntities);
   }
 
   /**

--- a/src/main/java/com/project/trainingdiary/service/TrainerCommentService.java
+++ b/src/main/java/com/project/trainingdiary/service/TrainerCommentService.java
@@ -1,0 +1,10 @@
+package com.project.trainingdiary.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TrainerCommentService {
+
+}


### PR DESCRIPTION
### 변경사항

- **트레이너 댓글 기능 구현 셋팅**:
  - 트레이너가 식단에 댓글을 달 수 있는 기능을 위한 초기 셋팅.
  - 댓글 엔티티, 레포지토리, 서비스, 컨트롤러 생성 및 설정.
  - TrainerComment 엔티티 생성으로 인해 Diet 관련 API 수정.
  - 식단 조회 시 댓글 목록 포함 기능 추가.

### 관련 이슈 및 반영 브랜치

- **Issue**: #101    
- **Branch**: 
  - FROM: `feature/trainer-comment-setup`
  - TO: `master`

---

## 설명

이번 변경사항은 트레이너가 식단에 댓글을 달 수 있는 기능을 구현하기 위한 초기 셋팅을 포함하고 있습니다. 이를 위해 댓글 엔티티, 레포지토리, 서비스, 컨트롤러를 생성하고 설정하였습니다. 또한, TrainerComment 엔티티가 생기면서 Diet 관련 API를 수정하여 트레이너의 댓글 목록까지 조회할 수 있도록 구현했습니다.

### ASIS

- 기존에는 트레이너가 식단에 댓글을 달 수 있는 기능이 없었습니다.

### TOBE

- 트레이너는 식단에 댓글을 달 수 있는 초기 셋팅이 완료되었습니다.
- 트레이너 댓글 엔티티 (`TrainerComment`)가 생성되었습니다.
- 트레이너 댓글 레포지토리 (`TrainerCommentRepository`)가 생성되었습니다.
- 트레이너 댓글 서비스 (`TrainerCommentService`)가 생성되었습니다.
- 트레이너 댓글 컨트롤러 (`TrainerCommentController`)가 생성되었습니다.
- Diet 관련 API가 수정되어 댓글 조회 기능이 추가되었습니다.

### 참고 사항

- 새로운 엔티티와 기능이 기존 시스템과 호환되는지 확인해야 합니다.

### 결론

이번 변경사항을 통해 트레이너가 식단에 댓글을 달 수 있는 기능을 위한 초기 셋팅을 완료하였습니다. 이를 통해 시스템의 기능성과 사용자 경험을 향상시킬 준비를 마쳤습니다. 새로운 기능이 기존 시스템과 호환되도록 리팩토링을 진행하였으며, 이를 통해 전체적인 코드의 품질을 높였습니다.