### PR TITLE
Jackson 모듈 및 타임존 설정 추가

### DIFF
--- a/src/main/java/com/project/trainingdiary/config/AppConfig.java
+++ b/src/main/java/com/project/trainingdiary/config/AppConfig.java
@@ -1,19 +1,61 @@
 package com.project.trainingdiary.config;
 
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.annotation.PostConstruct;
 import jakarta.persistence.EntityManager;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.TimeZone;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
+@Slf4j
 public class AppConfig {
+
+  /**
+   * 애플리케이션의 기본 시간대를 Asia/Seoul로 설정합니다. 이 메서드는 빈이 생성된 후 호출됩니다.
+   */
+  @PostConstruct
+  public void init() {
+    TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+    log.info("기본 시간대를 Asia/Seoul로 설정했습니다.");
+  }
+
+  /**
+   * LocalDate 및 LocalDateTime에 대한 커스텀 직렬화기 및 역직렬화기를 설정합니다. 이 모듈은 Jackson ObjectMapper에 등록됩니다.
+   */
+  @Bean
+  public Module jacksonModule() {
+    SimpleModule simpleModule = new SimpleModule();
+
+    // LocalDate
+    DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+    simpleModule.addDeserializer(LocalDate.class, new LocalDateDeserializer(dateFormatter));
+    simpleModule.addSerializer(LocalDate.class, new LocalDateSerializer(dateFormatter));
+
+    // LocalDateTime
+    DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+    simpleModule.addDeserializer(LocalDateTime.class,
+        new LocalDateTimeDeserializer(dateTimeFormatter));
+    simpleModule.addSerializer(LocalDateTime.class, new LocalDateTimeSerializer(dateTimeFormatter));
+
+    return simpleModule;
+  }
 
   /**
    * 비밀번호 암호화를 위한 Encoder를 Bean으로 등록합니다.
    */
-
   @Bean
   public PasswordEncoder passwordEncoder() {
     return new BCryptPasswordEncoder();

--- a/src/main/java/com/project/trainingdiary/util/VerificationCodeGeneratorUtil.java
+++ b/src/main/java/com/project/trainingdiary/util/VerificationCodeGeneratorUtil.java
@@ -1,7 +1,6 @@
 package com.project.trainingdiary.util;
 
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 
 public class VerificationCodeGeneratorUtil {
@@ -19,7 +18,7 @@ public class VerificationCodeGeneratorUtil {
   }
 
   public static String generateExpirationTime() {
-    LocalDateTime expirationDateTime = LocalDateTime.now(ZoneId.of("Asia/Seoul")).plusMinutes(10);
+    LocalDateTime expirationDateTime = LocalDateTime.now().plusMinutes(10);
     DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
     return expirationDateTime.format(formatter);
   }


### PR DESCRIPTION
### 변경사항

- **애플리케이션 설정 개선**:
  - 기본 시간대를 `Asia/Seoul`로 설정.
  - `LocalDate` 및 `LocalDateTime`에 대한 커스텀 직렬화기 및 역직렬화기 설정.

### 관련 이슈 및 반영 브랜치

- **Issue**: #108  
- **Branch**: 
  - FROM: `feature/jackson-config`
  - TO: `master`

---

## 설명

이번 변경사항은 애플리케이션 설정을 개선하기 위한 것입니다. 애플리케이션의 기본 시간대를 `Asia/Seoul`로 설정하고, `LocalDate` 및 `LocalDateTime`에 대한 커스텀 직렬화기 및 역직렬화기를 설정하였습니다. 이로 인해 날짜와 시간의 직렬화 및 역직렬화 시 일관성을 유지할 수 있습니다. 또한, 이를 통해 개발자가 수동으로 시간대를 설정할 필요가 없어졌으며, JSON 형식으로 날짜를 처리하는 과정이 단순화되었습니다.

### ASIS

- 기존에는 애플리케이션의 시간대가 명시적으로 설정되어 있지 않았습니다.
- `LocalDate` 및 `LocalDateTime`에 대한 직렬화 및 역직렬화가 일관되지 않았습니다.
- 개발자가 수동으로 시간대를 설정해야 했습니다.

### TOBE

- 애플리케이션의 기본 시간대가 `Asia/Seoul`로 설정됩니다.
- `LocalDate` 및 `LocalDateTime`에 대한 커스텀 직렬화기 및 역직렬화기가 설정됩니다.
- 개발자가 수동으로 시간대를 설정할 필요가 없습니다.
- JSON 형식으로 날짜를 처리하는 과정이 단순화됩니다.

### 참고 사항

- 새로운 설정이 기존 시스템과 호환되는지 확인해야 합니다.
- 설정 변경에 따른 API 문서 업데이트가 필요할 수 있습니다.
- 해당 변경 사항은 로컬 환경에서 테스트되어 정상적으로 작동하는 것을 확인하였습니다.

---

### 코드 변경 예시

#### AppConfig.java

```java
import com.fasterxml.jackson.databind.Module;
import com.fasterxml.jackson.databind.module.SimpleModule;
import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
import java.time.LocalDate;
import java.time.LocalDateTime;
import java.time.format.DateTimeFormatter;
import java.util.TimeZone;
import javax.annotation.PostConstruct;
import lombok.extern.slf4j.Slf4j;
import org.springframework.context.annotation.Bean;
import org.springframework.context.annotation.Configuration;

@Slf4j
@Configuration
public class AppConfig {

  /**
   * 애플리케이션의 기본 시간대를 Asia/Seoul로 설정합니다. 이 메서드는 빈이 생성된 후 호출됩니다.
   */
  @PostConstruct
  public void init() {
    TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
    log.info("기본 시간대를 Asia/Seoul로 설정했습니다.");
  }

  /**
   * LocalDate 및 LocalDateTime에 대한 커스텀 직렬화기 및 역직렬화기를 설정합니다. 이 모듈은 Jackson ObjectMapper에 등록됩니다.
   */
  @Bean
  public Module jacksonModule() {
    SimpleModule simpleModule = new SimpleModule();

    // LocalDate
    DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
    simpleModule.addDeserializer(LocalDate.class, new LocalDateDeserializer(dateFormatter));
    simpleModule.addSerializer(LocalDate.class, new LocalDateSerializer(dateFormatter));

    // LocalDateTime
    DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
    simpleModule.addDeserializer(LocalDateTime.class,
        new LocalDateTimeDeserializer(dateTimeFormatter));
    simpleModule.addSerializer(LocalDateTime.class, new LocalDateTimeSerializer(dateTimeFormatter));

    return simpleModule;
  }
}
```

### 결론

이번 변경사항을 통해 애플리케이션의 시간대 설정과 날짜 및 시간 직렬화 및 역직렬화 방식을 개선하였습니다. 이를 통해 시스템의 일관성을 유지하고, 사용자 경험을 향상시킬 수 있습니다. 또한, 수동 설정의 필요성을 제거하고 JSON 형식으로 날짜를 처리하는 과정을 단순화하여 개발 편의성을 높였습니다. 해당 변경 사항은 로컬 환경에서 테스트되어 정상적으로 작동하는 것을 확인하였습니다.