### PR TITLE
일정 상태 응답의 필드 이름을 scheduleStatus로 통일

### DIFF
--- a/src/main/java/com/project/trainingdiary/dto/response/schedule/ApplyScheduleResponseDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/response/schedule/ApplyScheduleResponseDto.java
@@ -11,5 +11,5 @@ import lombok.Setter;
 public class ApplyScheduleResponseDto {
 
   private long scheduleId;
-  private ScheduleStatusType scheduleStatusType;
+  private ScheduleStatusType scheduleStatus;
 }

--- a/src/main/java/com/project/trainingdiary/dto/response/schedule/CancelScheduleByTraineeResponseDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/response/schedule/CancelScheduleByTraineeResponseDto.java
@@ -11,5 +11,5 @@ import lombok.Setter;
 public class CancelScheduleByTraineeResponseDto {
 
   private long scheduleId;
-  private ScheduleStatusType scheduleStatusType;
+  private ScheduleStatusType scheduleStatus;
 }

--- a/src/main/java/com/project/trainingdiary/dto/response/schedule/CancelScheduleByTrainerResponseDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/response/schedule/CancelScheduleByTrainerResponseDto.java
@@ -11,5 +11,5 @@ import lombok.Setter;
 public class CancelScheduleByTrainerResponseDto {
 
   private long scheduleId;
-  private ScheduleStatusType scheduleStatusType;
+  private ScheduleStatusType scheduleStatus;
 }

--- a/src/main/java/com/project/trainingdiary/dto/response/schedule/RejectScheduleResponseDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/response/schedule/RejectScheduleResponseDto.java
@@ -11,5 +11,5 @@ import lombok.Setter;
 public class RejectScheduleResponseDto {
 
   private long scheduleId;
-  private ScheduleStatusType scheduleStatusType;
+  private ScheduleStatusType scheduleStatus;
 }

--- a/src/main/java/com/project/trainingdiary/model/ScheduleResponseDetail.java
+++ b/src/main/java/com/project/trainingdiary/model/ScheduleResponseDetail.java
@@ -20,5 +20,5 @@ public class ScheduleResponseDetail {
   private String trainerName;
   private Long traineeId;
   private String traineeName;
-  private ScheduleStatusType status;
+  private ScheduleStatusType scheduleStatus;
 }

--- a/src/main/java/com/project/trainingdiary/repository/schedule/ScheduleRepositoryImpl.java
+++ b/src/main/java/com/project/trainingdiary/repository/schedule/ScheduleRepositoryImpl.java
@@ -107,14 +107,14 @@ public class ScheduleRepositoryImpl implements ScheduleRepositoryCustom {
                   .traineeId(getTraineeId(tuple, includeOnlyThisTraineeId))
                   .traineeName(getTraineeName(tuple, includeOnlyThisTraineeId))
                   .startTime(LocalTime.parse(Objects.requireNonNull(tuple.get(startTime()))))
-                  .status(tuple.get(scheduleEntity.scheduleStatusType))
+                  .scheduleStatus(tuple.get(scheduleEntity.scheduleStatusType))
                   .build()
               )
               .collect(Collectors.toList());
 
           // 해당 날짜에 예약이 존재하는지 검사
           boolean existReserved = details.stream()
-              .anyMatch(detail -> detail.getStatus() == ScheduleStatusType.RESERVED);
+              .anyMatch(detail -> detail.getScheduleStatus() == ScheduleStatusType.RESERVED);
 
           return ScheduleResponseDto.builder()
               .startDate(date)

--- a/src/test/java/com/project/trainingdiary/service/ScheduleOpenCloseServiceTest.java
+++ b/src/test/java/com/project/trainingdiary/service/ScheduleOpenCloseServiceTest.java
@@ -183,15 +183,15 @@ class ScheduleOpenCloseServiceTest {
             .details(List.of(
                 ScheduleResponseDetail.builder()
                     .startTime(LocalTime.of(10, 0))
-                    .status(ScheduleStatusType.RESERVED)
+                    .scheduleStatus(ScheduleStatusType.RESERVED)
                     .build(),
                 ScheduleResponseDetail.builder()
                     .startTime(LocalTime.of(11, 0))
-                    .status(ScheduleStatusType.OPEN)
+                    .scheduleStatus(ScheduleStatusType.OPEN)
                     .build(),
                 ScheduleResponseDetail.builder()
                     .startTime(LocalTime.of(12, 0))
-                    .status(ScheduleStatusType.OPEN)
+                    .scheduleStatus(ScheduleStatusType.OPEN)
                     .build()
             ))
             .build(),
@@ -201,15 +201,15 @@ class ScheduleOpenCloseServiceTest {
             .details(List.of(
                 ScheduleResponseDetail.builder()
                     .startTime(LocalTime.of(20, 0))
-                    .status(ScheduleStatusType.OPEN)
+                    .scheduleStatus(ScheduleStatusType.OPEN)
                     .build(),
                 ScheduleResponseDetail.builder()
                     .startTime(LocalTime.of(21, 0))
-                    .status(ScheduleStatusType.OPEN)
+                    .scheduleStatus(ScheduleStatusType.OPEN)
                     .build(),
                 ScheduleResponseDetail.builder()
                     .startTime(LocalTime.of(22, 0))
-                    .status(ScheduleStatusType.OPEN)
+                    .scheduleStatus(ScheduleStatusType.OPEN)
                     .build()
             ))
             .build()

--- a/src/test/java/com/project/trainingdiary/service/ScheduleTraineeServiceTest.java
+++ b/src/test/java/com/project/trainingdiary/service/ScheduleTraineeServiceTest.java
@@ -188,15 +188,15 @@ class ScheduleTraineeServiceTest {
             .details(List.of(
                 ScheduleResponseDetail.builder()
                     .startTime(LocalTime.of(10, 0))
-                    .status(ScheduleStatusType.RESERVED)
+                    .scheduleStatus(ScheduleStatusType.RESERVED)
                     .build(),
                 ScheduleResponseDetail.builder()
                     .startTime(LocalTime.of(11, 0))
-                    .status(ScheduleStatusType.OPEN)
+                    .scheduleStatus(ScheduleStatusType.OPEN)
                     .build(),
                 ScheduleResponseDetail.builder()
                     .startTime(LocalTime.of(12, 0))
-                    .status(ScheduleStatusType.OPEN)
+                    .scheduleStatus(ScheduleStatusType.OPEN)
                     .build()
             ))
             .build(),
@@ -206,15 +206,15 @@ class ScheduleTraineeServiceTest {
             .details(List.of(
                 ScheduleResponseDetail.builder()
                     .startTime(LocalTime.of(20, 0))
-                    .status(ScheduleStatusType.OPEN)
+                    .scheduleStatus(ScheduleStatusType.OPEN)
                     .build(),
                 ScheduleResponseDetail.builder()
                     .startTime(LocalTime.of(21, 0))
-                    .status(ScheduleStatusType.OPEN)
+                    .scheduleStatus(ScheduleStatusType.OPEN)
                     .build(),
                 ScheduleResponseDetail.builder()
                     .startTime(LocalTime.of(22, 0))
-                    .status(ScheduleStatusType.OPEN)
+                    .scheduleStatus(ScheduleStatusType.OPEN)
                     .build()
             ))
             .build()
@@ -446,7 +446,7 @@ class ScheduleTraineeServiceTest {
 
     assertEquals(4, ptContractCaptor.getValue().getUsedSession());
     assertEquals(ScheduleStatusType.OPEN, scheduleCaptor.getValue().getScheduleStatusType());
-    assertEquals(ScheduleStatusType.OPEN, response.getScheduleStatusType());
+    assertEquals(ScheduleStatusType.OPEN, response.getScheduleStatus());
   }
 
   @Test

--- a/src/test/java/com/project/trainingdiary/service/ScheduleTrainerServiceTest.java
+++ b/src/test/java/com/project/trainingdiary/service/ScheduleTrainerServiceTest.java
@@ -156,15 +156,15 @@ class ScheduleTrainerServiceTest {
             .details(List.of(
                 ScheduleResponseDetail.builder()
                     .startTime(LocalTime.of(10, 0))
-                    .status(ScheduleStatusType.RESERVED)
+                    .scheduleStatus(ScheduleStatusType.RESERVED)
                     .build(),
                 ScheduleResponseDetail.builder()
                     .startTime(LocalTime.of(11, 0))
-                    .status(ScheduleStatusType.OPEN)
+                    .scheduleStatus(ScheduleStatusType.OPEN)
                     .build(),
                 ScheduleResponseDetail.builder()
                     .startTime(LocalTime.of(12, 0))
-                    .status(ScheduleStatusType.OPEN)
+                    .scheduleStatus(ScheduleStatusType.OPEN)
                     .build()
             ))
             .build(),
@@ -174,15 +174,15 @@ class ScheduleTrainerServiceTest {
             .details(List.of(
                 ScheduleResponseDetail.builder()
                     .startTime(LocalTime.of(20, 0))
-                    .status(ScheduleStatusType.OPEN)
+                    .scheduleStatus(ScheduleStatusType.OPEN)
                     .build(),
                 ScheduleResponseDetail.builder()
                     .startTime(LocalTime.of(21, 0))
-                    .status(ScheduleStatusType.OPEN)
+                    .scheduleStatus(ScheduleStatusType.OPEN)
                     .build(),
                 ScheduleResponseDetail.builder()
                     .startTime(LocalTime.of(22, 0))
-                    .status(ScheduleStatusType.OPEN)
+                    .scheduleStatus(ScheduleStatusType.OPEN)
                     .build()
             ))
             .build()
@@ -466,7 +466,7 @@ class ScheduleTrainerServiceTest {
 
     assertEquals(4, ptContractCaptor.getValue().getUsedSession());
     assertEquals(ScheduleStatusType.OPEN, scheduleCaptor.getValue().getScheduleStatusType());
-    assertEquals(ScheduleStatusType.OPEN, response.getScheduleStatusType());
+    assertEquals(ScheduleStatusType.OPEN, response.getScheduleStatus());
   }
 
   @Test


### PR DESCRIPTION
### 변경사항

<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요 -->
**AS-IS**
- 기존에 같은 내용에 대해 2개의 다른 필드이름으로 나가고 있었음

**TO-BE**
- scheduleStatusType과 status를 scheduleStatus로 통일

### 테스트

<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 

- [x] 테스트 코드
  - 기존 유닛 테스트 동작 확인
- [x] API 테스트
  - GET api/schedules 의 필드 이름 확인

Resolves #102 