### PR TITLE
트레이너 댓글 삭제 기능 구현 API

### DIFF
--- a/src/main/java/com/project/trainingdiary/controller/CommentController.java
+++ b/src/main/java/com/project/trainingdiary/controller/CommentController.java
@@ -11,6 +11,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -58,10 +59,19 @@ public class CommentController {
     return ResponseEntity.ok().build();
   }
 
-  @PostMapping("{id}")
+  @Operation(
+      summary = "식단 댓글 삭제",
+      description = "식단 댓글를 삭제합니다."
+  )
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "성공"),
+  })
+  @PreAuthorize("hasRole('TRAINER')")
+  @DeleteMapping("{id}")
   public ResponseEntity<Void> deleteTrainerComment(
       @PathVariable Long id
   ) {
+    commentService.deleteTrainerComment(id);
     return ResponseEntity.ok().build();
   }
 }

--- a/src/main/java/com/project/trainingdiary/dto/response/comment/CommentDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/response/comment/CommentDto.java
@@ -1,7 +1,7 @@
 package com.project.trainingdiary.dto.response.comment;
 
 import com.project.trainingdiary.entity.CommentEntity;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,13 +11,13 @@ public class CommentDto {
 
   private Long id;
   private String comment;
-  private LocalDateTime createdDate;
+  private LocalDate createdDate;
 
   public static CommentDto fromEntity(CommentEntity comment) {
     return CommentDto.builder()
         .id(comment.getId())
         .comment(comment.getComment())
-        .createdDate(comment.getCreatedAt())
+        .createdDate(comment.getCreatedAt().toLocalDate())
         .build();
   }
 }

--- a/src/main/java/com/project/trainingdiary/dto/response/diet/DietDetailsInfoResponseDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/response/diet/DietDetailsInfoResponseDto.java
@@ -3,7 +3,7 @@ package com.project.trainingdiary.dto.response.diet;
 import com.project.trainingdiary.dto.response.comment.CommentDto;
 import com.project.trainingdiary.entity.CommentEntity;
 import com.project.trainingdiary.entity.DietEntity;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,12 +16,13 @@ public class DietDetailsInfoResponseDto {
   private String imageUrl;
   private String content;
   private List<CommentDto> comments;
-  private LocalDateTime createdDate;
+  private LocalDate createdDate;
 
   public static DietDetailsInfoResponseDto of(DietEntity diet,
       List<CommentEntity> comments) {
 
-    List<CommentDto> commentDtos = comments.stream()
+    List<CommentDto> commentDto = comments.stream()
+        .sorted((a, b) -> b.getCreatedAt().compareTo(a.getCreatedAt()))
         .map(CommentDto::fromEntity)
         .toList();
 
@@ -29,8 +30,8 @@ public class DietDetailsInfoResponseDto {
         .id(diet.getId())
         .imageUrl(diet.getOriginalUrl())
         .content(diet.getContent())
-        .comments(commentDtos)
-        .createdDate(diet.getCreatedAt())
+        .comments(commentDto)
+        .createdDate(diet.getCreatedAt().toLocalDate())
         .build();
   }
 }

--- a/src/main/java/com/project/trainingdiary/entity/BaseEntity.java
+++ b/src/main/java/com/project/trainingdiary/entity/BaseEntity.java
@@ -5,6 +5,7 @@ import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -15,6 +16,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @MappedSuperclass
 @Getter
+@Setter
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {
 

--- a/src/main/java/com/project/trainingdiary/repository/DietRepository.java
+++ b/src/main/java/com/project/trainingdiary/repository/DietRepository.java
@@ -5,10 +5,25 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface DietRepository extends JpaRepository<DietEntity, Long> {
 
   Page<DietEntity> findByTraineeId(Long traineeId, Pageable pageable);
 
   Optional<DietEntity> findByTraineeIdAndId(Long id, Long id1);
+
+  @Query("SELECT d FROM diet d " +
+      "LEFT JOIN FETCH d.comments c " +
+      "LEFT JOIN FETCH c.trainer " +
+      "WHERE d.id = :id")
+  Optional<DietEntity> findByIdWithCommentsAndTrainer(@Param("id") Long id);
+
+  @Query("SELECT d FROM diet d " +
+      "LEFT JOIN FETCH d.comments c " +
+      "LEFT JOIN FETCH c.trainer " +
+      "WHERE d.id = :id AND d.trainee.id = :traineeId")
+  Optional<DietEntity> findByTraineeIdAndIdWithCommentsAndTrainer(
+      @Param("traineeId") Long traineeId, @Param("id") Long id);
 }

--- a/src/main/java/com/project/trainingdiary/service/CommentService.java
+++ b/src/main/java/com/project/trainingdiary/service/CommentService.java
@@ -25,13 +25,21 @@ public class CommentService {
   private final DietRepository dietRepository;
   private final TrainerRepository trainerRepository;
 
+  /**
+   * 트레이너가 새로운 댓글을 추가합니다.
+   *
+   * @param dto 댓글 추가 요청 DTO
+   * @throws DietNotExistException    주어진 식단 ID에 해당하는 식단이 없을 경우 예외 발생
+   * @throws TrainerNotFoundException 인증된 트레이너가 존재하지 않을 경우 예외 발생
+   */
   public void addTrainerComment(AddCommentRequestDto dto) {
-
     TrainerEntity trainer = getAuthenticatedTrainer();
 
+    // 주어진 식단 ID에 해당하는 식단 조회 및 예외 처리
     DietEntity diet = dietRepository.findById(dto.getId())
         .orElseThrow(DietNotExistException::new);
 
+    // 새로운 댓글 엔티티 생성 및 저장
     CommentEntity comment = CommentEntity.builder()
         .comment(dto.getComment())
         .trainer(trainer)
@@ -41,19 +49,51 @@ public class CommentService {
     commentRepository.save(comment);
   }
 
-
+  /**
+   * 트레이너가 기존 댓글을 수정합니다.
+   *
+   * @param dto 댓글 수정 요청 DTO
+   * @throws CommentNotExistException     주어진 댓글 ID에 해당하는 댓글이 없을 경우 예외 발생
+   * @throws UnauthorizedCommentException 댓글 작성자가 현재 인증된 트레이너가 아닐 경우 예외 발생
+   * @throws TrainerNotFoundException     인증된 트레이너가 존재하지 않을 경우 예외 발생
+   */
   public void updateTrainerComment(UpdateCommentRequestDto dto) {
     TrainerEntity trainer = getAuthenticatedTrainer();
 
+    // 주어진 댓글 ID에 해당하는 댓글 조회 및 예외 처리
     CommentEntity comment = commentRepository.findById(dto.getId())
         .orElseThrow(CommentNotExistException::new);
 
+    // 댓글 작성자가 현재 인증된 트레이너가 아닐 경우 예외 발생
     if (!comment.getTrainer().equals(trainer)) {
       throw new UnauthorizedCommentException();
     }
 
     comment.setComment(dto.getComment());
     commentRepository.save(comment);
+  }
+
+  /**
+   * 트레이너가 댓글을 삭제합니다.
+   *
+   * @param id 삭제할 댓글 ID
+   * @throws CommentNotExistException     주어진 댓글 ID에 해당하는 댓글이 없을 경우 예외 발생
+   * @throws UnauthorizedCommentException 댓글 작성자가 현재 인증된 트레이너가 아닐 경우 예외 발생
+   * @throws TrainerNotFoundException     인증된 트레이너가 존재하지 않을 경우 예외 발생
+   */
+  public void deleteTrainerComment(Long id) {
+    TrainerEntity trainer = getAuthenticatedTrainer();
+
+    // 주어진 댓글 ID에 해당하는 댓글 조회 및 예외 처리
+    CommentEntity comment = commentRepository.findById(id)
+        .orElseThrow(CommentNotExistException::new);
+
+    // 댓글 작성자가 현재 인증된 트레이너가 아닐 경우 예외 발생
+    if (!comment.getTrainer().equals(trainer)) {
+      throw new UnauthorizedCommentException();
+    }
+
+    commentRepository.delete(comment);
   }
 
   /**

--- a/src/main/java/com/project/trainingdiary/service/DietService.java
+++ b/src/main/java/com/project/trainingdiary/service/DietService.java
@@ -13,7 +13,6 @@ import com.project.trainingdiary.exception.user.TrainerNotFoundException;
 import com.project.trainingdiary.exception.user.UserNotFoundException;
 import com.project.trainingdiary.exception.workout.InvalidFileTypeException;
 import com.project.trainingdiary.model.type.UserRoleType;
-import com.project.trainingdiary.repository.CommentRepository;
 import com.project.trainingdiary.repository.DietRepository;
 import com.project.trainingdiary.repository.TraineeRepository;
 import com.project.trainingdiary.repository.TrainerRepository;
@@ -39,7 +38,6 @@ public class DietService {
   private final TraineeRepository traineeRepository;
   private final TrainerRepository trainerRepository;
   private final PtContractRepository ptContractRepository;
-  private final CommentRepository commentRepository;
 
   private final ImageUtil imageUtil;
 
@@ -160,7 +158,7 @@ public class DietService {
   private DietDetailsInfoResponseDto getDietDetailsInfoForTrainee(Long id) {
     TraineeEntity trainee = getAuthenticatedTrainee();
 
-    DietEntity diet = dietRepository.findByTraineeIdAndId(trainee.getId(), id)
+    DietEntity diet = dietRepository.findByTraineeIdAndIdWithCommentsAndTrainer(trainee.getId(), id)
         .orElseThrow(DietNotExistException::new);
 
     return DietDetailsInfoResponseDto.of(diet, diet.getComments());
@@ -176,7 +174,7 @@ public class DietService {
   private DietDetailsInfoResponseDto getDietDetailsInfoForTrainer(Long id) {
     TrainerEntity trainer = getAuthenticatedTrainer();
 
-    DietEntity diet = dietRepository.findById(id)
+    DietEntity diet = dietRepository.findByIdWithCommentsAndTrainer(id)
         .orElseThrow(DietNotExistException::new);
 
     hasContractWithTrainee(trainer, diet.getTrainee());

--- a/src/test/java/com/project/trainingdiary/service/CommentServiceTest.java
+++ b/src/test/java/com/project/trainingdiary/service/CommentServiceTest.java
@@ -236,6 +236,67 @@ class CommentServiceTest {
     when(commentRepository.findById(dto.getId())).thenReturn(Optional.of(anotherComment));
 
     // then
-    assertThrows(UnauthorizedCommentException.class, () -> commentService.updateTrainerComment(dto));
+    assertThrows(UnauthorizedCommentException.class,
+        () -> commentService.updateTrainerComment(dto));
+  }
+
+  @Test
+  @DisplayName("트레이너 댓글 삭제 - 성공")
+  void deleteTrainerComment_Success() {
+    // given
+    setupTrainerAuth();
+    Long commentId = comment.getId();
+
+    // when
+    when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
+
+    // execute
+    commentService.deleteTrainerComment(commentId);
+
+    // then
+    verify(commentRepository).delete(comment);
+  }
+
+  @Test
+  @DisplayName("트레이너 댓글 삭제 - 실패(존재하지 않는 댓글)")
+  void deleteTrainerComment_Fail_CommentNotExist() {
+    // given
+    setupTrainerAuth();
+    Long commentId = 99L; // Non-existent comment ID
+
+    // when
+    when(commentRepository.findById(commentId)).thenReturn(Optional.empty());
+
+    // then
+    assertThrows(CommentNotExistException.class,
+        () -> commentService.deleteTrainerComment(commentId));
+  }
+
+  @Test
+  @DisplayName("트레이너 댓글 삭제 - 실패(권한 없음)")
+  void deleteTrainerComment_Fail_Unauthorized() {
+    // given
+    setupTrainerAuth();
+    TrainerEntity anotherTrainer = TrainerEntity.builder()
+        .id(2L)
+        .email("another_trainer@example.com")
+        .name("Another Trainer")
+        .build();
+
+    CommentEntity anotherComment = CommentEntity.builder()
+        .id(comment.getId())
+        .comment("Initial Comment")
+        .trainer(anotherTrainer)
+        .diet(comment.getDiet())
+        .build();
+
+    Long commentId = anotherComment.getId();
+
+    // when
+    when(commentRepository.findById(commentId)).thenReturn(Optional.of(anotherComment));
+
+    // then
+    assertThrows(UnauthorizedCommentException.class,
+        () -> commentService.deleteTrainerComment(commentId));
   }
 }

--- a/src/test/java/com/project/trainingdiary/service/DietServiceTest.java
+++ b/src/test/java/com/project/trainingdiary/service/DietServiceTest.java
@@ -37,6 +37,7 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
@@ -331,8 +332,10 @@ public class DietServiceTest {
     diet.setContent("Test content");
     diet.setOriginalUrl("https://test-bucket.s3.amazonaws.com/original.jpg");
     diet.setComments(Collections.emptyList());
+    diet.setCreatedAt(LocalDateTime.now());
 
-    when(dietRepository.findByTraineeIdAndId(trainee.getId(), diet.getId())).thenReturn(
+    when(dietRepository.findByTraineeIdAndIdWithCommentsAndTrainer(trainee.getId(),
+        diet.getId())).thenReturn(
         Optional.of(diet));
 
     DietDetailsInfoResponseDto response = dietService.getDietDetails(diet.getId());
@@ -391,8 +394,9 @@ public class DietServiceTest {
     diet.setContent("Test content");
     diet.setOriginalUrl("https://test-bucket.s3.amazonaws.com/original.jpg");
     diet.setComments(Collections.emptyList());
+    diet.setCreatedAt(LocalDateTime.now());
 
-    when(dietRepository.findById(diet.getId())).thenReturn(Optional.of(diet));
+    when(dietRepository.findByIdWithCommentsAndTrainer(diet.getId())).thenReturn(Optional.of(diet));
     when(ptContractRepository.findByTrainerIdAndTraineeId(trainer.getId(), traineeToView.getId()))
         .thenReturn(Optional.of(new PtContractEntity()));
 
@@ -416,7 +420,7 @@ public class DietServiceTest {
     diet.setId(1L);
     diet.setTrainee(traineeToView);
 
-    when(dietRepository.findById(diet.getId())).thenReturn(Optional.of(diet));
+    when(dietRepository.findByIdWithCommentsAndTrainer(diet.getId())).thenReturn(Optional.of(diet));
     when(ptContractRepository.findByTrainerIdAndTraineeId(trainer.getId(), traineeToView.getId()))
         .thenReturn(Optional.empty());
 


### PR DESCRIPTION
### 변경사항

- **트레이너 댓글 삭제 기능 구현**:
  - 트레이너가 작성한 댓글을 삭제할 수 있는 기능 추가.
  - 댓글 삭제 API (`DELETE /api/comments/{id}`) 구현.
  - 댓글 삭제 기능에 대한 유닛 테스트 및 통합 테스트 작성.
  - JPQL을 사용하여 트레이니의 식단 정보를 조회하는 쿼리 개선.

### 관련 이슈 및 반영 브랜치

- **Issue**: #121 
- **Branch**: 
  - FROM: `feature/delete-comment`
  - TO: `master`

---

## 설명

이번 변경사항은 트레이너가 작성한 댓글을 삭제할 수 있는 기능을 구현하는 것입니다. 이를 위해 댓글 삭제 API를 구현하고, 댓글 삭제 기능에 대한 유닛 테스트 및 통합 테스트를 작성하여 각 기능을 검증하였습니다. 또한, 트레이니의 식단 정보를 조회하는 쿼리를 JPQL을 사용하여 개선하였습니다.

### ASIS

- 기존에는 트레이너가 작성한 댓글을 삭제할 수 있는 기능이 없었습니다.
- 트레이니의 식단 정보를 조회하는 쿼리가 최적화되지 않았습니다.

### TOBE

- 트레이너는 작성한 댓글을 삭제할 수 있습니다.
- 댓글 삭제 API (`DELETE /api/comments/{id}`)가 구현되었습니다.
- 댓글 삭제 기능에 대한 유닛 테스트 및 통합 테스트가 작성되었습니다.
- JPQL을 사용하여 트레이니의 식단 정보를 효율적으로 조회할 수 있습니다.

### 참고 사항

- 새로운 API가 기존 시스템과 호환되는지 확인해야 합니다.
- API 문서 작성 및 업데이트가 필요합니다.

---

### API 문서

#### DELETE /api/comments/{id} - 트레이너 댓글 삭제

##### 요청

- URL 경로 매개변수: `id` (삭제할 댓글의 ID)

#### 예외 응답

- 존재하지 않는 댓글을 삭제하려고 할 때:
  ```json
  {
    "error": "CommentNotFoundException",
    "message": "존재하지 않는 댓글입니다."
  }
  ```

- 트레이너가 본인의 댓글이 아닌 다른 댓글을 삭제하려고 할 때:
  ```json
  {
    "error": "UnauthorizedException",
    "message": "트레이너는 자신의 댓글만 삭제할 수 있습니다."
  }
  ```

### 테스트 케이스

- 트레이너가 댓글을 성공적으로 삭제할 수 있는지 확인하는 유닛 테스트.
- 존재하지 않는 댓글을 삭제하려고 할 때 예외가 발생하는지 확인하는 유닛 테스트.
- 권한이 없는 트레이너가 다른 트레이너의 댓글을 삭제하려고 할 때 예외가 발생하는지 확인하는 유닛 테스트.
- JPQL을 사용한 트레이니 식단 정보 조회 쿼리가 올바르게 작동하는지 확인하는 통합 테스트.

### 결론

이번 변경사항을 통해 트레이너가 작성한 댓글을 삭제할 수 있는 기능을 구현하였습니다. 이를 통해 시스템의 기능성과 사용자 경험을 향상시킬 수 있습니다. 또한, JPQL을 사용하여 트레이니의 식단 정보를 효율적으로 조회할 수 있도록 쿼리를 개선하였습니다.