### PR TITLE
클라이언트에서 받는 에러 코드를 간소화

### DIFF
--- a/src/main/java/com/project/trainingdiary/controller/PtContractController.java
+++ b/src/main/java/com/project/trainingdiary/controller/PtContractController.java
@@ -71,8 +71,7 @@ public class PtContractController {
       description = "트레이너가 PT 계약을 종료함"
   )
   @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", description = "성공"),
-      @ApiResponse(responseCode = "404", description = "계약이 없습니다.")
+      @ApiResponse(responseCode = "200", description = "성공")
   })
   @PreAuthorize("hasRole('TRAINER')")
   @PostMapping("/terminate")

--- a/src/main/java/com/project/trainingdiary/controller/ScheduleController.java
+++ b/src/main/java/com/project/trainingdiary/controller/ScheduleController.java
@@ -51,8 +51,7 @@ public class ScheduleController {
       description = "트레이너가 예약 가능한 일정을 열어놓음"
   )
   @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", description = "성공"),
-      @ApiResponse(responseCode = "409", description = "같은 시간에 이미 일정이 존재합니다.", content = @Content)
+      @ApiResponse(responseCode = "200", description = "성공")
   })
   @PreAuthorize("hasRole('TRAINER')")
   @PostMapping("/trainers/open")
@@ -68,8 +67,7 @@ public class ScheduleController {
       description = "트레이너가 기간 내의 일정을 조회함. (조회 간격은 최대 180일)"
   )
   @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", description = "성공"),
-      @ApiResponse(responseCode = "413", description = "일정 간격이 너무 깁니다.", content = @Content)
+      @ApiResponse(responseCode = "200", description = "성공")
   })
   @PreAuthorize("hasRole('TRAINER')")
   @GetMapping("/trainers")
@@ -85,8 +83,7 @@ public class ScheduleController {
       description = "트레이니가 기간 내의 일정을 조회함. (조회 간격은 최대 180일)"
   )
   @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", description = "성공"),
-      @ApiResponse(responseCode = "413", description = "일정 간격이 너무 깁니다.", content = @Content)
+      @ApiResponse(responseCode = "200", description = "성공")
   })
   @PreAuthorize("hasRole('TRAINEE')")
   @GetMapping("/trainees")
@@ -102,9 +99,7 @@ public class ScheduleController {
       description = "트레이너가 예약 가능한 일정을 닫음"
   )
   @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", description = "성공"),
-      @ApiResponse(responseCode = "404", description = "일정이 없습니다.", content = @Content),
-      @ApiResponse(responseCode = "409", description = "일정이 OPEN 상태가 아닙니다.", content = @Content)
+      @ApiResponse(responseCode = "200", description = "성공")
   })
   @PreAuthorize("hasRole('TRAINER')")
   @PostMapping("/trainers/close")
@@ -121,10 +116,7 @@ public class ScheduleController {
   )
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "성공"),
-      @ApiResponse(responseCode = "404", description = "일정이 없습니다.", content = @Content),
-      @ApiResponse(responseCode = "409", description = "일정이 OPEN 상태가 아닙니다.", content = @Content),
-      @ApiResponse(responseCode = "412", description = "과거의 일정은 예약할 수 없습니다.", content = @Content),
-      @ApiResponse(responseCode = "417", description = "1시간 내 시작하는 일정은 예약할 수 없습니다.", content = @Content)
+      @ApiResponse(responseCode = "406", description = "남은 PT 횟수가 부족합니다.", content = @Content)
   })
   @PreAuthorize("hasRole('TRAINEE')")
   @PostMapping("/trainees/apply")
@@ -139,10 +131,7 @@ public class ScheduleController {
       description = "트레이너가 일정을 수락함"
   )
   @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", description = "성공"),
-      @ApiResponse(responseCode = "404", description = "일정이 없습니다.", content = @Content),
-      @ApiResponse(responseCode = "409", description = "일정의 상태가 RESERVE_APPLIED가 아닙니다.", content = @Content),
-      @ApiResponse(responseCode = "417", description = "전체 세션 갯수를 다 사용했습니다.", content = @Content)
+      @ApiResponse(responseCode = "200", description = "성공")
   })
   @PreAuthorize("hasRole('TRAINER')")
   @PostMapping("/trainers/accept")
@@ -158,9 +147,7 @@ public class ScheduleController {
       description = "트레이너가 일정을 거절함"
   )
   @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", description = "성공"),
-      @ApiResponse(responseCode = "404", description = "일정이 없습니다.", content = @Content),
-      @ApiResponse(responseCode = "409", description = "일정의 상태가 RESERVE_APPLIED가 아닙니다.", content = @Content)
+      @ApiResponse(responseCode = "200", description = "성공")
   })
   @PreAuthorize("hasRole('TRAINER')")
   @PostMapping("/trainers/reject")
@@ -176,8 +163,7 @@ public class ScheduleController {
   )
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "성공"),
-      @ApiResponse(responseCode = "406", description = "PT 횟수가 부족합니다.", content = @Content),
-      @ApiResponse(responseCode = "409", description = "일정이 OPEN 상태가 아닙니다.", content = @Content)
+      @ApiResponse(responseCode = "406", description = "남은 PT 횟수가 부족합니다.", content = @Content)
   })
   @PreAuthorize("hasRole('TRAINER')")
   @PostMapping("/trainers/register")
@@ -192,9 +178,7 @@ public class ScheduleController {
       description = "트레이너가 일정을 취소함. 일정에 연결된 트레이니가 없어지고 OPEN 상태로 변경됨"
   )
   @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", description = "성공"),
-      @ApiResponse(responseCode = "404", description = "일정이 없습니다.", content = @Content),
-      @ApiResponse(responseCode = "409", description = "일정의 상태가 RESERVED나 RESERVE_APPLIED가 아닙니다.", content = @Content),
+      @ApiResponse(responseCode = "200", description = "성공")
   })
   @PreAuthorize("hasRole('TRAINER')")
   @PostMapping("/trainers/cancel")
@@ -209,10 +193,7 @@ public class ScheduleController {
       description = "트레이니가 일정을 취소함"
   )
   @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", description = "성공"),
-      @ApiResponse(responseCode = "404", description = "일정이 없습니다.", content = @Content),
-      @ApiResponse(responseCode = "409", description = "일정의 상태가 RESERVED나 RESERVE_APPLIED가 아닙니다.", content = @Content),
-      @ApiResponse(responseCode = "417", description = "일정이 하루 안에 시작되므로 취소할 수 없습니다.", content = @Content)
+      @ApiResponse(responseCode = "200", description = "성공")
   })
   @PreAuthorize("hasRole('TRAINEE')")
   @PostMapping("/trainees/cancel")

--- a/src/main/java/com/project/trainingdiary/exception/ptcontract/PtContractNotEnoughSessionException.java
+++ b/src/main/java/com/project/trainingdiary/exception/ptcontract/PtContractNotEnoughSessionException.java
@@ -6,6 +6,6 @@ import org.springframework.http.HttpStatus;
 public class PtContractNotEnoughSessionException extends GlobalException {
 
   public PtContractNotEnoughSessionException() {
-    super(HttpStatus.NOT_ACCEPTABLE, "PT 횟수가 부족합니다.");
+    super(HttpStatus.NOT_ACCEPTABLE, "남은 PT 횟수가 부족합니다.");
   }
 }

--- a/src/main/java/com/project/trainingdiary/exception/schedule/ScheduleAlreadyExistException.java
+++ b/src/main/java/com/project/trainingdiary/exception/schedule/ScheduleAlreadyExistException.java
@@ -6,6 +6,6 @@ import org.springframework.http.HttpStatus;
 public class ScheduleAlreadyExistException extends GlobalException {
 
   public ScheduleAlreadyExistException() {
-    super(HttpStatus.CONFLICT, "같은 시간에 이미 일정이 존재합니다.");
+    super(HttpStatus.BAD_REQUEST, "같은 시간에 이미 일정이 존재합니다.");
   }
 }

--- a/src/main/java/com/project/trainingdiary/exception/schedule/ScheduleRangeTooLongException.java
+++ b/src/main/java/com/project/trainingdiary/exception/schedule/ScheduleRangeTooLongException.java
@@ -6,6 +6,6 @@ import org.springframework.http.HttpStatus;
 public class ScheduleRangeTooLongException extends GlobalException {
 
   public ScheduleRangeTooLongException() {
-    super(HttpStatus.PAYLOAD_TOO_LARGE, "일정 간격이 너무 깁니다.");
+    super(HttpStatus.BAD_REQUEST, "일정 간격이 너무 깁니다.");
   }
 }

--- a/src/main/java/com/project/trainingdiary/exception/schedule/ScheduleStartIsPastException.java
+++ b/src/main/java/com/project/trainingdiary/exception/schedule/ScheduleStartIsPastException.java
@@ -6,6 +6,6 @@ import org.springframework.http.HttpStatus;
 public class ScheduleStartIsPastException extends GlobalException {
 
   public ScheduleStartIsPastException() {
-    super(HttpStatus.CONFLICT, "과거의 일정은 예약할 수 없습니다.");
+    super(HttpStatus.BAD_REQUEST, "과거의 일정은 예약할 수 없습니다.");
   }
 }

--- a/src/main/java/com/project/trainingdiary/exception/schedule/ScheduleStartTooSoonException.java
+++ b/src/main/java/com/project/trainingdiary/exception/schedule/ScheduleStartTooSoonException.java
@@ -6,6 +6,6 @@ import org.springframework.http.HttpStatus;
 public class ScheduleStartTooSoonException extends GlobalException {
 
   public ScheduleStartTooSoonException() {
-    super(HttpStatus.EXPECTATION_FAILED, "1시간 내 시작하는 일정은 예약할 수 없습니다.");
+    super(HttpStatus.BAD_REQUEST, "1시간 내 시작하는 일정은 예약할 수 없습니다.");
   }
 }

--- a/src/main/java/com/project/trainingdiary/exception/schedule/ScheduleStartWithin1DayException.java
+++ b/src/main/java/com/project/trainingdiary/exception/schedule/ScheduleStartWithin1DayException.java
@@ -6,6 +6,6 @@ import org.springframework.http.HttpStatus;
 public class ScheduleStartWithin1DayException extends GlobalException {
 
   public ScheduleStartWithin1DayException() {
-    super(HttpStatus.EXPECTATION_FAILED, "일정이 하루 안에 시작되므로 취소할 수 없습니다.");
+    super(HttpStatus.BAD_REQUEST, "일정이 하루 안에 시작되므로 취소할 수 없습니다.");
   }
 }

--- a/src/main/java/com/project/trainingdiary/exception/schedule/ScheduleStatusNotOpenException.java
+++ b/src/main/java/com/project/trainingdiary/exception/schedule/ScheduleStatusNotOpenException.java
@@ -6,6 +6,6 @@ import org.springframework.http.HttpStatus;
 public class ScheduleStatusNotOpenException extends GlobalException {
 
   public ScheduleStatusNotOpenException() {
-    super(HttpStatus.CONFLICT, "일정이 OPEN 상태가 아닙니다.");
+    super(HttpStatus.BAD_REQUEST, "일정이 OPEN 상태가 아닙니다.");
   }
 }

--- a/src/main/java/com/project/trainingdiary/exception/schedule/ScheduleStatusNotReserveAppliedException.java
+++ b/src/main/java/com/project/trainingdiary/exception/schedule/ScheduleStatusNotReserveAppliedException.java
@@ -6,6 +6,6 @@ import org.springframework.http.HttpStatus;
 public class ScheduleStatusNotReserveAppliedException extends GlobalException {
 
   public ScheduleStatusNotReserveAppliedException() {
-    super(HttpStatus.CONFLICT, "일정의 상태가 RESERVE_APPLIED가 아닙니다.");
+    super(HttpStatus.BAD_REQUEST, "일정의 상태가 RESERVE_APPLIED가 아닙니다.");
   }
 }

--- a/src/main/java/com/project/trainingdiary/exception/schedule/ScheduleStatusNotReserveAppliedOrReservedException.java
+++ b/src/main/java/com/project/trainingdiary/exception/schedule/ScheduleStatusNotReserveAppliedOrReservedException.java
@@ -6,6 +6,6 @@ import org.springframework.http.HttpStatus;
 public class ScheduleStatusNotReserveAppliedOrReservedException extends GlobalException {
 
   public ScheduleStatusNotReserveAppliedOrReservedException() {
-    super(HttpStatus.CONFLICT, "일정의 상태가 RESERVED나 RESERVE_APPLIED가 아닙니다.");
+    super(HttpStatus.BAD_REQUEST, "일정의 상태가 RESERVED나 RESERVE_APPLIED가 아닙니다.");
   }
 }

--- a/src/main/java/com/project/trainingdiary/service/ScheduleTraineeService.java
+++ b/src/main/java/com/project/trainingdiary/service/ScheduleTraineeService.java
@@ -14,6 +14,7 @@ import com.project.trainingdiary.entity.TrainerEntity;
 import com.project.trainingdiary.exception.notification.UnsupportedNotificationTypeException;
 import com.project.trainingdiary.exception.ptcontract.PtContractNotEnoughSessionException;
 import com.project.trainingdiary.exception.ptcontract.PtContractNotExistException;
+import com.project.trainingdiary.exception.ptcontract.UsedSessionExceededTotalSessionException;
 import com.project.trainingdiary.exception.schedule.ScheduleNotFoundException;
 import com.project.trainingdiary.exception.schedule.ScheduleRangeTooLongException;
 import com.project.trainingdiary.exception.schedule.ScheduleStartIsPastException;

--- a/src/main/java/com/project/trainingdiary/service/ScheduleTrainerService.java
+++ b/src/main/java/com/project/trainingdiary/service/ScheduleTrainerService.java
@@ -72,10 +72,6 @@ public class ScheduleTrainerService {
     if (ptContract == null) {
       throw new PtContractNotExistException();
     }
-    // 전체 세션의 갯수와 사용한 세션의 갯수를 비교해 더 사용할 수 있는지 확인
-    if (ptContract.getTotalSession() <= ptContract.getUsedSession()) {
-      throw new UsedSessionExceededTotalSessionException();
-    }
 
     // 일정 수락
     schedule.acceptReserveApplied();

--- a/src/test/java/com/project/trainingdiary/service/ScheduleTrainerServiceTest.java
+++ b/src/test/java/com/project/trainingdiary/service/ScheduleTrainerServiceTest.java
@@ -317,37 +317,6 @@ class ScheduleTrainerServiceTest {
   }
 
   @Test
-  @DisplayName("일정 수락 - 실패(모든 세션 횟수를 사용함)")
-  void acceptScheduleFail_UsedAllSession() {
-    //given
-    setupTrainerAuth();
-    AcceptScheduleRequestDto dto = new AcceptScheduleRequestDto();
-    dto.setScheduleId(100L);
-
-    //when
-    when(scheduleRepository.findById(100L))
-        .thenReturn(Optional.of(
-            ScheduleEntity.builder()
-                .id(100L)
-                .scheduleStatusType(ScheduleStatusType.RESERVE_APPLIED)
-                .ptContract(
-                    PtContractEntity.builder()
-                        .id(1000L)
-                        .totalSession(10)
-                        .usedSession(10) // 모두 사용
-                        .build()
-                )
-                .build()
-        ));
-
-    //then
-    assertThrows(
-        UsedSessionExceededTotalSessionException.class,
-        () -> scheduleTrainerService.acceptSchedule(dto)
-    );
-  }
-
-  @Test
   @DisplayName("일정 거절 - 성공")
   void rejectSchedule() {
     //given


### PR DESCRIPTION
### 변경사항

<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요 -->
**AS-IS**
- 서버의 각 예외에 따른 에러 코드를 세분화하여 클라이언트로 전달함

**TO-BE**
- 이미 클라이언트에서 검증을 거치고 들어온 값에 대해서는 일반 에러코드를 내보내도록 수정
  - 서버에서도 검증을 하지만, 서버 검증 결과에 따른 에러를 모두 세분화된 클라이언트 에러 코드로 만들어 내보내지 않음
- 클라이언트에서 서버를 호출해야만 알 수 있는 에러에 대해 에러코드를 세분화함
- 간소화된 에러 코드를 Swagger 문서에 반영

### 테스트

<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 

- [x] 테스트 코드
  - 기존 유닛 테스트의 실행여부 확인

Resolves #105 