### PR TITLE
PT 계약 생성 시 없는 이메일을 등록할 경우 에러코드로 406이 나가도록 수정

### DIFF
--- a/src/main/java/com/project/trainingdiary/controller/PtContractController.java
+++ b/src/main/java/com/project/trainingdiary/controller/PtContractController.java
@@ -39,6 +39,7 @@ public class PtContractController {
   )
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "성공"),
+      @ApiResponse(responseCode = "406", description = "트레이니 이메일이 존재하지 않아 계약할 수 없습니다.", content = @Content),
       @ApiResponse(responseCode = "409", description = "트레이너와 트레이니가 이미 계약이 있습니다.", content = @Content)
   })
   @PreAuthorize("hasRole('TRAINER')")

--- a/src/main/java/com/project/trainingdiary/exception/ptcontract/PtContractTrainerEmailNotExistException.java
+++ b/src/main/java/com/project/trainingdiary/exception/ptcontract/PtContractTrainerEmailNotExistException.java
@@ -1,0 +1,11 @@
+package com.project.trainingdiary.exception.ptcontract;
+
+import com.project.trainingdiary.exception.GlobalException;
+import org.springframework.http.HttpStatus;
+
+public class PtContractTrainerEmailNotExistException extends GlobalException {
+
+  public PtContractTrainerEmailNotExistException() {
+    super(HttpStatus.NOT_ACCEPTABLE, "트레이니 이메일이 존재하지 않아 계약할 수 없습니다.");
+  }
+}

--- a/src/main/java/com/project/trainingdiary/service/PtContractService.java
+++ b/src/main/java/com/project/trainingdiary/service/PtContractService.java
@@ -13,6 +13,7 @@ import com.project.trainingdiary.entity.TrainerEntity;
 import com.project.trainingdiary.exception.notification.UnsupportedNotificationTypeException;
 import com.project.trainingdiary.exception.ptcontract.PtContractAlreadyExistException;
 import com.project.trainingdiary.exception.ptcontract.PtContractNotExistException;
+import com.project.trainingdiary.exception.ptcontract.PtContractTrainerEmailNotExistException;
 import com.project.trainingdiary.exception.user.UserNotFoundException;
 import com.project.trainingdiary.model.NotificationMessage;
 import com.project.trainingdiary.model.PtContractSort;
@@ -45,7 +46,8 @@ public class PtContractService {
    */
   public CreatePtContractResponseDto createPtContract(CreatePtContractRequestDto dto) {
     TrainerEntity trainer = getTrainer();
-    TraineeEntity trainee = getTrainee(dto.getTraineeEmail());
+    TraineeEntity trainee = traineeRepository.findByEmail(dto.getTraineeEmail())
+        .orElseThrow(PtContractTrainerEmailNotExistException::new);
 
     if (ptContractRepository.existsByTrainerIdAndTraineeId(trainer.getId(), trainee.getId())) {
       throw new PtContractAlreadyExistException();
@@ -110,11 +112,6 @@ public class PtContractService {
       throw new UserNotFoundException();
     }
     return trainerRepository.findByEmail(auth.getName())
-        .orElseThrow(UserNotFoundException::new);
-  }
-
-  private TraineeEntity getTrainee(String email) {
-    return traineeRepository.findByEmail(email)
         .orElseThrow(UserNotFoundException::new);
   }
 

--- a/src/test/java/com/project/trainingdiary/service/PtContractServiceTest.java
+++ b/src/test/java/com/project/trainingdiary/service/PtContractServiceTest.java
@@ -17,7 +17,7 @@ import com.project.trainingdiary.entity.TraineeEntity;
 import com.project.trainingdiary.entity.TrainerEntity;
 import com.project.trainingdiary.exception.ptcontract.PtContractAlreadyExistException;
 import com.project.trainingdiary.exception.ptcontract.PtContractNotExistException;
-import com.project.trainingdiary.exception.user.UserNotFoundException;
+import com.project.trainingdiary.exception.ptcontract.PtContractTrainerEmailNotExistException;
 import com.project.trainingdiary.model.PtContractSort;
 import com.project.trainingdiary.model.UserPrincipal;
 import com.project.trainingdiary.model.type.NotificationType;
@@ -181,7 +181,7 @@ class PtContractServiceTest {
 
     //then
     assertThrows(
-        UserNotFoundException.class,
+        PtContractTrainerEmailNotExistException.class,
         () -> ptContractService.createPtContract(dto)
     );
   }


### PR DESCRIPTION
### 변경사항

<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요 -->
**AS-IS**
- PT 계약 생성 시 없는 이메일을 등록할 경우 에러코드로 404가 나감

**TO-BE**
- PT 계약 생성 시 없는 이메일을 등록할 경우 에러코드로 406이 나가도록 수정
- Swagger 문서에 반영

### 테스트

<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 

- [x] 테스트 코드
  - Exception 종류 수정
- [x] API 테스트
  - POST api/pt-contracts
  - 해당 API로 없는 이메일을 넣었을 때 에러코드 406 확인

Resolves #136 