### PR TITLE
PT 계약에서 직접 날짜 시간 포맷팅을 하지 않고, 전역 옵션을 사용

### DIFF
--- a/src/main/java/com/project/trainingdiary/dto/response/ptcontract/PtContractResponseDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/response/ptcontract/PtContractResponseDto.java
@@ -1,7 +1,6 @@
 package com.project.trainingdiary.dto.response.ptcontract;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-import java.time.ZonedDateTime;
+import java.time.LocalDate;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -12,9 +11,7 @@ import lombok.Setter;
 public class PtContractResponseDto {
 
   private Long ptContractId;
-
-  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX", timezone = "Asia/Seoul")
-  private ZonedDateTime totalSessionUpdatedAt;
+  private LocalDate totalSessionUpdatedAt;
   private int remainingSession;
   private Long trainerId;
   private String trainerName;

--- a/src/main/java/com/project/trainingdiary/entity/PtContractEntity.java
+++ b/src/main/java/com/project/trainingdiary/entity/PtContractEntity.java
@@ -10,7 +10,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -86,7 +85,7 @@ public class PtContractEntity extends BaseEntity {
         .traineeId(trainee.getId())
         .traineeName(trainee.getName())
         .remainingSession(getRemainingSession())
-        .totalSessionUpdatedAt(totalSessionUpdatedAt.atZone(ZoneId.of("Asia/Seoul")))
+        .totalSessionUpdatedAt(totalSessionUpdatedAt.toLocalDate())
         .build();
   }
 }

--- a/src/main/java/com/project/trainingdiary/service/ScheduleTraineeService.java
+++ b/src/main/java/com/project/trainingdiary/service/ScheduleTraineeService.java
@@ -14,7 +14,6 @@ import com.project.trainingdiary.entity.TrainerEntity;
 import com.project.trainingdiary.exception.notification.UnsupportedNotificationTypeException;
 import com.project.trainingdiary.exception.ptcontract.PtContractNotEnoughSessionException;
 import com.project.trainingdiary.exception.ptcontract.PtContractNotExistException;
-import com.project.trainingdiary.exception.ptcontract.UsedSessionExceededTotalSessionException;
 import com.project.trainingdiary.exception.schedule.ScheduleNotFoundException;
 import com.project.trainingdiary.exception.schedule.ScheduleRangeTooLongException;
 import com.project.trainingdiary.exception.schedule.ScheduleStartIsPastException;

--- a/src/main/java/com/project/trainingdiary/service/ScheduleTrainerService.java
+++ b/src/main/java/com/project/trainingdiary/service/ScheduleTrainerService.java
@@ -14,7 +14,6 @@ import com.project.trainingdiary.entity.TraineeEntity;
 import com.project.trainingdiary.entity.TrainerEntity;
 import com.project.trainingdiary.exception.notification.UnsupportedNotificationTypeException;
 import com.project.trainingdiary.exception.ptcontract.PtContractNotExistException;
-import com.project.trainingdiary.exception.ptcontract.UsedSessionExceededTotalSessionException;
 import com.project.trainingdiary.exception.schedule.ScheduleNotFoundException;
 import com.project.trainingdiary.exception.schedule.ScheduleRangeTooLongException;
 import com.project.trainingdiary.exception.schedule.ScheduleStatusNotReserveAppliedException;

--- a/src/test/java/com/project/trainingdiary/service/ScheduleTraineeServiceTest.java
+++ b/src/test/java/com/project/trainingdiary/service/ScheduleTraineeServiceTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.project.trainingdiary.component.FcmPushNotification;
-import com.project.trainingdiary.dto.request.schedule.AcceptScheduleRequestDto;
 import com.project.trainingdiary.dto.request.schedule.ApplyScheduleRequestDto;
 import com.project.trainingdiary.dto.request.schedule.CancelScheduleByTraineeRequestDto;
 import com.project.trainingdiary.dto.response.schedule.CancelScheduleByTraineeResponseDto;
@@ -22,7 +21,6 @@ import com.project.trainingdiary.entity.TraineeEntity;
 import com.project.trainingdiary.entity.TrainerEntity;
 import com.project.trainingdiary.exception.ptcontract.PtContractNotEnoughSessionException;
 import com.project.trainingdiary.exception.ptcontract.PtContractNotExistException;
-import com.project.trainingdiary.exception.ptcontract.UsedSessionExceededTotalSessionException;
 import com.project.trainingdiary.exception.schedule.ScheduleNotFoundException;
 import com.project.trainingdiary.exception.schedule.ScheduleStartIsPastException;
 import com.project.trainingdiary.exception.schedule.ScheduleStartTooSoonException;

--- a/src/test/java/com/project/trainingdiary/service/ScheduleTrainerServiceTest.java
+++ b/src/test/java/com/project/trainingdiary/service/ScheduleTrainerServiceTest.java
@@ -22,7 +22,6 @@ import com.project.trainingdiary.entity.ScheduleEntity;
 import com.project.trainingdiary.entity.TraineeEntity;
 import com.project.trainingdiary.entity.TrainerEntity;
 import com.project.trainingdiary.exception.ptcontract.PtContractNotExistException;
-import com.project.trainingdiary.exception.ptcontract.UsedSessionExceededTotalSessionException;
 import com.project.trainingdiary.exception.schedule.ScheduleNotFoundException;
 import com.project.trainingdiary.exception.schedule.ScheduleRangeTooLongException;
 import com.project.trainingdiary.exception.schedule.ScheduleStatusNotReserveAppliedException;


### PR DESCRIPTION
### 변경사항

<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요 -->
**AS-IS**
- PT 계약 DTO에서 직접 날짜 시간 포맷팅을 적용하고 있음

**TO-BE**
- PT 계약에서 직접 날짜 시간 포맷팅을 하지 않고, 전역 옵션을 사용
- PT 계약에서 시간은 사용되지 않으므로 날짜만으로 수정

### 테스트

<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 

- [x] API 테스트
  - GET api/pt-contracts 결과 확인
```json
{
  "content": [
    {
      "ptContractId": 4,
      "totalSessionUpdatedAt": "2024-07-24",
      "remainingSession": 28,
      "trainerId": 1,
      "trainerName": "이충경",
      "traineeId": 1,
      "traineeName": "이충경"
    }
  ],
  "pageable": {
    "pageNumber": 0,
    "pageSize": 10,
    "sort": {
      "empty": true,
      "unsorted": true,
      "sorted": false
    },
    "offset": 0,
    "unpaged": false,
    "paged": true
  },
  "last": true,
  "totalPages": 1,
  "totalElements": 1,
  "first": true,
  "size": 10,
  "number": 0,
  "sort": {
    "empty": true,
    "unsorted": true,
    "sorted": false
  },
  "numberOfElements": 1,
  "empty": false
}
```

Resolves #137 