### PR TITLE
Redis 토큰 삭제 버그 수정 및 User Cache 도입 기능 형상

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,9 @@ dependencies {
     // FFmpeg
     implementation 'net.bramp.ffmpeg:ffmpeg:0.8.0'
 
+    // Caffeine
+    implementation 'com.github.ben-manes.caffeine:caffeine:3.1.6'
+
     // Querydsl
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"

--- a/src/main/java/com/project/trainingdiary/config/CacheConfig.java
+++ b/src/main/java/com/project/trainingdiary/config/CacheConfig.java
@@ -3,19 +3,18 @@ package com.project.trainingdiary.config;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.project.trainingdiary.model.UserPrincipal;
+import java.util.concurrent.TimeUnit;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import java.util.concurrent.TimeUnit;
 
 @Configuration
 public class CacheConfig {
 
-    @Bean
-    public Cache<String, UserPrincipal> userCache() {
-        return Caffeine.newBuilder()
-                .expireAfterWrite(10, TimeUnit.MINUTES)
-                .maximumSize(1000)
-                .build();
-    }
+  @Bean
+  public Cache<String, UserPrincipal> userCache() {
+    return Caffeine.newBuilder()
+        .expireAfterWrite(10, TimeUnit.MINUTES)
+        .maximumSize(1000)
+        .build();
+  }
 }

--- a/src/main/java/com/project/trainingdiary/config/CacheConfig.java
+++ b/src/main/java/com/project/trainingdiary/config/CacheConfig.java
@@ -1,0 +1,21 @@
+package com.project.trainingdiary.config;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.project.trainingdiary.model.UserPrincipal;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+public class CacheConfig {
+
+    @Bean
+    public Cache<String, UserPrincipal> userCache() {
+        return Caffeine.newBuilder()
+                .expireAfterWrite(10, TimeUnit.MINUTES)
+                .maximumSize(1000)
+                .build();
+    }
+}

--- a/src/main/java/com/project/trainingdiary/dto/request/trainer/EditTraineeInfoRequestDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/request/trainer/EditTraineeInfoRequestDto.java
@@ -31,7 +31,6 @@ public class EditTraineeInfoRequestDto {
   private double height;
 
   @Schema(example = "5")
-  @Positive(message = "remainingSession 값은 양수이어야 합니다.")
   private int remainingSession;
 
   @Schema(example = "TARGET_WEIGHT", allowableValues = {"TARGET_WEIGHT",

--- a/src/main/java/com/project/trainingdiary/dto/response/trainer/TraineeInfoResponseDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/response/trainer/TraineeInfoResponseDto.java
@@ -58,19 +58,22 @@ public class TraineeInfoResponseDto {
     return birthDate != null ? Period.between(birthDate, LocalDate.now()).getYears() : 0;
   }
 
-  private static List<WeightHistoryDto> mapToWeightHistory(List<InBodyRecordHistoryEntity> inBodyRecords) {
+  private static List<WeightHistoryDto> mapToWeightHistory(
+      List<InBodyRecordHistoryEntity> inBodyRecords) {
     return inBodyRecords.stream()
         .map(WeightHistoryDto::fromEntity)
         .collect(Collectors.toList());
   }
 
-  private static List<BodyFatHistoryDto> mapToBodyFatHistory(List<InBodyRecordHistoryEntity> inBodyRecords) {
+  private static List<BodyFatHistoryDto> mapToBodyFatHistory(
+      List<InBodyRecordHistoryEntity> inBodyRecords) {
     return inBodyRecords.stream()
         .map(BodyFatHistoryDto::fromEntity)
         .collect(Collectors.toList());
   }
 
-  private static List<MuscleMassHistoryDto> mapToMuscleMassHistory(List<InBodyRecordHistoryEntity> inBodyRecords) {
+  private static List<MuscleMassHistoryDto> mapToMuscleMassHistory(
+      List<InBodyRecordHistoryEntity> inBodyRecords) {
     return inBodyRecords.stream()
         .map(MuscleMassHistoryDto::fromEntity)
         .collect(Collectors.toList());

--- a/src/main/java/com/project/trainingdiary/model/UserPrincipal.java
+++ b/src/main/java/com/project/trainingdiary/model/UserPrincipal.java
@@ -3,14 +3,13 @@ package com.project.trainingdiary.model;
 import com.project.trainingdiary.entity.TraineeEntity;
 import com.project.trainingdiary.entity.TrainerEntity;
 import com.project.trainingdiary.model.type.UserRoleType;
+import java.util.Collection;
+import java.util.Collections;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
-
-import java.util.Collection;
-import java.util.Collections;
 
 @Getter
 @AllArgsConstructor

--- a/src/main/java/com/project/trainingdiary/model/UserPrincipal.java
+++ b/src/main/java/com/project/trainingdiary/model/UserPrincipal.java
@@ -7,11 +7,13 @@ import java.util.Collection;
 import java.util.Collections;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 @Getter
+@Setter
 @AllArgsConstructor
 public class UserPrincipal implements UserDetails {
 
@@ -20,7 +22,6 @@ public class UserPrincipal implements UserDetails {
   private final String password;
   private final String name;
   private final UserRoleType role;
-  private final boolean unreadNotification;
   private final Collection<? extends GrantedAuthority> authorities;
   private final boolean isTrainer;
   private final TrainerEntity trainer;
@@ -33,7 +34,6 @@ public class UserPrincipal implements UserDetails {
         trainee.getPassword(),
         trainee.getName(),
         UserRoleType.TRAINEE,
-        trainee.isUnreadNotification(),
         Collections.singletonList(new SimpleGrantedAuthority("ROLE_TRAINEE")),
         false,
         null,
@@ -48,7 +48,6 @@ public class UserPrincipal implements UserDetails {
         trainer.getPassword(),
         trainer.getName(),
         UserRoleType.TRAINER,
-        trainer.isUnreadNotification(),
         Collections.singletonList(new SimpleGrantedAuthority("ROLE_TRAINER")),
         true,
         trainer,

--- a/src/main/java/com/project/trainingdiary/model/UserPrincipal.java
+++ b/src/main/java/com/project/trainingdiary/model/UserPrincipal.java
@@ -2,33 +2,58 @@ package com.project.trainingdiary.model;
 
 import com.project.trainingdiary.entity.TraineeEntity;
 import com.project.trainingdiary.entity.TrainerEntity;
-import java.util.Collection;
-import java.util.Collections;
+import com.project.trainingdiary.model.type.UserRoleType;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import java.util.Collection;
+import java.util.Collections;
+
+@Getter
 @AllArgsConstructor
 public class UserPrincipal implements UserDetails {
 
+  private final Long id;
   private final String email;
   private final String password;
+  private final String name;
+  private final UserRoleType role;
+  private final boolean unreadNotification;
   private final Collection<? extends GrantedAuthority> authorities;
+  private final boolean isTrainer;
+  private final TrainerEntity trainer;
+  private final TraineeEntity trainee;
 
   public static UserPrincipal create(TraineeEntity trainee) {
     return new UserPrincipal(
+        trainee.getId(),
         trainee.getEmail(),
         trainee.getPassword(),
-        Collections.singletonList(new SimpleGrantedAuthority("ROLE_TRAINEE"))
+        trainee.getName(),
+        UserRoleType.TRAINEE,
+        trainee.isUnreadNotification(),
+        Collections.singletonList(new SimpleGrantedAuthority("ROLE_TRAINEE")),
+        false,
+        null,
+        trainee
     );
   }
 
   public static UserPrincipal create(TrainerEntity trainer) {
     return new UserPrincipal(
+        trainer.getId(),
         trainer.getEmail(),
         trainer.getPassword(),
-        Collections.singletonList(new SimpleGrantedAuthority("ROLE_TRAINER"))
+        trainer.getName(),
+        UserRoleType.TRAINER,
+        trainer.isUnreadNotification(),
+        Collections.singletonList(new SimpleGrantedAuthority("ROLE_TRAINER")),
+        true,
+        trainer,
+        null
     );
   }
 

--- a/src/main/java/com/project/trainingdiary/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/project/trainingdiary/security/JwtAuthenticationFilter.java
@@ -97,6 +97,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     UserDetails userDetails = userService.loadUserByUsername(username);
 
     if (userDetails != null) {
+      String previousAccessTokenKey = "accessToken:" + username;
+
+      redisTokenRepository.deleteToken(previousAccessTokenKey);
+
       String newAccessToken = tokenProvider.createAccessToken(username);
       log.info("새로운 접근 토큰을 쿠키에 설정: {}", newAccessToken);
 

--- a/src/main/java/com/project/trainingdiary/service/UserService.java
+++ b/src/main/java/com/project/trainingdiary/service/UserService.java
@@ -388,7 +388,13 @@ public class UserService implements UserDetailsService {
     if (tokenCookie != null && tokenProvider.validateToken(tokenCookie.getValue())) {
       log.info("블랙리스트에 추가된 토큰: {}", tokenCookie.getValue());
       tokenProvider.blacklistToken(tokenCookie.getValue());
-      redisTokenRepository.deleteToken(tokenProvider.getUsernameFromToken(tokenCookie.getValue()));
+
+      String username = tokenProvider.getUsernameFromToken(tokenCookie.getValue());
+      String accessTokenKey = "accessToken:" + username;
+      String refreshTokenKey = "refreshToken:" + username;
+
+      redisTokenRepository.deleteToken(accessTokenKey);
+      redisTokenRepository.deleteToken(refreshTokenKey);
     }
   }
 

--- a/src/test/java/com/project/trainingdiary/service/ScheduleOpenCloseServiceTest.java
+++ b/src/test/java/com/project/trainingdiary/service/ScheduleOpenCloseServiceTest.java
@@ -422,7 +422,8 @@ class ScheduleOpenCloseServiceTest {
     ArgumentCaptor<List<ScheduleEntity>> captorSchedule = ArgumentCaptor.forClass(List.class);
     ArgumentCaptor<PtContractEntity> captorPtContract = ArgumentCaptor.forClass(
         PtContractEntity.class);
-    ArgumentCaptor<NotificationEntity> captorNotification = ArgumentCaptor.forClass(NotificationEntity.class);
+    ArgumentCaptor<NotificationEntity> captorNotification = ArgumentCaptor.forClass(
+        NotificationEntity.class);
 
     //then
     RegisterScheduleResponseDto response = scheduleOpenCloseService.registerSchedule(dto);

--- a/src/test/java/com/project/trainingdiary/service/UserServiceTest.java
+++ b/src/test/java/com/project/trainingdiary/service/UserServiceTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.github.benmanes.caffeine.cache.Cache;
 import com.project.trainingdiary.dto.request.user.SendVerificationAndCheckDuplicateRequestDto;
 import com.project.trainingdiary.dto.request.user.SignInRequestDto;
 import com.project.trainingdiary.dto.request.user.SignUpRequestDto;
@@ -29,6 +30,7 @@ import com.project.trainingdiary.exception.user.VerificationCodeNotFoundExceptio
 import com.project.trainingdiary.exception.user.VerificationCodeNotMatchedException;
 import com.project.trainingdiary.exception.user.VerificationCodeNotYetVerifiedException;
 import com.project.trainingdiary.exception.user.WrongPasswordException;
+import com.project.trainingdiary.model.UserPrincipal;
 import com.project.trainingdiary.model.type.UserRoleType;
 import com.project.trainingdiary.provider.CookieProvider;
 import com.project.trainingdiary.provider.EmailProvider;
@@ -82,6 +84,9 @@ public class UserServiceTest {
 
   @Mock
   private PasswordEncoder passwordEncoder;
+
+  @Mock
+  private Cache<String, UserPrincipal> userCache;
 
   @InjectMocks
   private UserService userService;


### PR DESCRIPTION
### 변경사항

- **Redis 토큰 삭제 버그 수정 및 기능 향상**:
  - Redis에서 로그아웃 시 토큰이 블랙리스트에 추가된 후 삭제되지 않는 문제 수정.
  - `UserPrincipal` 클래스에 필드를 추가하여 보안 관련 사용자 정보를 효율적으로 조회할 수 있도록 개선.
  - Caffeine 캐시를 사용하여 사용자 인증 정보 캐시 구현 (`com.github.ben-manes.caffeine:caffeine:3.1.6`).

### 관련 이슈 및 반영 브랜치

- **Issue**: #152
- **Branch**: 
  - FROM: `enhancement/redis-fix-user-cache`
  - TO: `master`

---

## 설명

이번 변경사항은 Redis에서 로그아웃 시 토큰이 블랙리스트에 추가된 후 삭제되지 않는 문제를 수정하고, 여러 기능을 향상시키는 것입니다. `UserPrincipal` 클래스에 필드를 추가하여 중복 코드를 줄이고 사용자 정보를 효율적으로 조회할 수 있도록 개선하였습니다. 또한, Caffeine 캐시를 사용하여 사용자 인증 정보를 캐시함으로써 데이터베이스 조회 부담을 줄였습니다.

유저 조회는 자주 사용되며 API 호출 시마다 반복적으로 발생하는 3개의 쿼리를 줄여 불필요한 쿼리를 없애는 방법을 고려한 것입니다.

### ASIS

- Redis에서 로그아웃 시 토큰이 블랙리스트에 추가된 후 삭제되지 않았습니다.
- 사용자 정보를 조회할 때 중복 코드가 많이 발생했습니다.
- 데이터베이스 조회 부담이 컸습니다.

### TOBE

- Redis에서 로그아웃 시 토큰이 블랙리스트에 추가된 후 정상적으로 삭제됩니다.
- `UserPrincipal` 클래스에 필드를 추가하여 중복 코드가 줄어들고 사용자 정보를 효율적으로 조회할 수 있습니다.
- Caffeine 캐시를 사용하여 사용자 인증 정보를 캐시하고, 데이터베이스 조회 부담이 줄어듭니다.

#### Caffeine 캐시의 장점:
1. **자동 만료 및 제거**:
   - Caffeine은 시간 기반 만료(`expireAfterWrite`, `expireAfterAccess`) 및 크기 기반 제거(`maximumSize`, `maximumWeight`)를 지원하여 캐시가 무한정 커지지 않고 오래된 항목이 자동으로 제거됩니다.
   - 기존의 Java 내장 캐시는 이러한 자동 만료 및 제거를 지원하지 않아 수동으로 구현해야 하며, 이는 복잡하고 오류가 발생할 수 있습니다.
2. **동시성 및 성능**:
   - Caffeine은 높은 동시성을 염두에 두고 설계되었으며, 최신 알고리즘과 데이터 구조를 사용하여 효율적인 스레드 안전 접근을 제공합니다. 특히, TinyLFU를 사용한 제거 정책은 높은 적중률을 유지하면서 메모리 오버헤드를 낮게 유지합니다.
   - Java 내장 캐시(`ConcurrentHashMap`)는 스레드 안전하지만, 캐시 시나리오에 최적화되어 있지 않고, 높은 동시성 하에서 성능 저하가 발생할 수 있습니다.

#### Caffeine 캐시의 단점:
- **사용자 정보 변경 빈도**:
  - 사용자 정보가 자주 변경되는 경우 캐시의 일관성을 유지하는 것이 어려울 수 있습니다. 하지만, 우리 프로젝트에서는 사용자 정보가 자주 변경되지 않기 때문에 이러한 문제는 발생하지 않습니다.

### 참고 사항

- 새로운 기능이 기존 시스템과 호환되는지 확인해야 합니다.

---

### 결론

이번 변경사항을 통해 Redis에서 로그아웃 시 토큰이 블랙리스트에 추가된 후 삭제되지 않는 문제를 수정하고, UserPrincipal 클래스와 Caffeine 캐시를 사용하여 시스템의 성능과 효율성을 향상시켰습니다. 이를 통해 시스템의 유지보수성과 확장성을 높일 수 있을 것으로 기대됩니다. 사용자 정보가 자주 변경되지 않는 우리 프로젝트의 특성상, Caffeine 캐시의 단점은 문제가 되지 않을 것입니다. 물론 in-memory 캐시를 사용하면서 메모리 부담이 커질 수 있지만, 현재 구조와 캐시에서 다루는 메모리 양은 서버에 부하를 일으킬 정도가 아니므로 자주 사용해도 문제되지 않습니다.