### PR TITLE
일정 열기 및 일정 등록 시 기존 일정을 가져올 때, 해당 트레이너의 일정만 가져오도록 함

### DIFF
--- a/src/main/java/com/project/trainingdiary/repository/schedule/ScheduleRepository.java
+++ b/src/main/java/com/project/trainingdiary/repository/schedule/ScheduleRepository.java
@@ -6,28 +6,42 @@ import java.util.List;
 import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ScheduleRepository extends JpaRepository<ScheduleEntity, Long>,
     ScheduleRepositoryCustom {
 
   @Query("select s.startAt "
       + "from schedule s "
-      + "where s.startAt >= ?1 "
-      + "and s.startAt <= ?2")
-  Set<LocalDateTime> findScheduleDatesByDates(LocalDateTime startAt1, LocalDateTime startAt2);
+      + "where s.trainer.id = :id "
+      + "and s.startAt >= :startAt1 "
+      + "and s.startAt <= :startAt2")
+  Set<LocalDateTime> findScheduleDatesByDates(
+      @Param("id") long id,
+      @Param("startAt1") LocalDateTime startAt1,
+      @Param("startAt2") LocalDateTime startAt2
+  );
 
   @Query("select s "
       + "from schedule s "
-      + "where s.startAt >= ?1 "
-      + "and s.startAt <= ?2")
-  List<ScheduleEntity> findByDates(LocalDateTime startAt1, LocalDateTime startAt2);
+      + "where s.trainer.id = :id "
+      + "and s.startAt >= :startAt1 "
+      + "and s.startAt <= :startAt2")
+  List<ScheduleEntity> findByDates(
+      @Param("id") long id,
+      @Param("startAt1") LocalDateTime startAt1,
+      @Param("startAt2") LocalDateTime startAt2
+  );
 
   @Query("select s "
       + "from schedule s "
       + "left join fetch s.trainer "
       + "left join fetch s.ptContract "
       + "left join fetch s.ptContract.trainee "
-      + "where s.startAt >= ?1 "
-      + "and s.startAt <= ?2")
-  List<ScheduleEntity> findByDatesWithDetails(LocalDateTime startAt1, LocalDateTime startAt2);
+      + "where s.startAt >= :startAt1 "
+      + "and s.startAt <= :startAt2")
+  List<ScheduleEntity> findByDatesWithDetails(
+      @Param("startAt1") LocalDateTime startAt1,
+      @Param("startAt2") LocalDateTime startAt2
+  );
 }

--- a/src/main/java/com/project/trainingdiary/service/ScheduleOpenCloseService.java
+++ b/src/main/java/com/project/trainingdiary/service/ScheduleOpenCloseService.java
@@ -56,6 +56,7 @@ public class ScheduleOpenCloseService {
 
     List<LocalDateTime> requestedStartTimes = getRequestedTimes(dto.getDateTimes());
     Set<LocalDateTime> existings = scheduleRepository.findScheduleDatesByDates(
+        trainer.getId(),
         getEarliest(requestedStartTimes),
         getLatest(requestedStartTimes)
     );
@@ -106,6 +107,7 @@ public class ScheduleOpenCloseService {
 
     List<LocalDateTime> requestedStartTimes = getRequestedTimes(dto.getDateTimes());
     Set<LocalDateTime> existingStartTimes = scheduleRepository.findScheduleDatesByDates(
+        trainer.getId(),
         getEarliest(requestedStartTimes),
         getLatest(requestedStartTimes)
     );
@@ -123,7 +125,7 @@ public class ScheduleOpenCloseService {
 
     // 이미 존재하는 일정은 기존 일정을 사용해서 업데이트
     List<ScheduleEntity> existingSchedules = updateExistingSchedules(
-        existingStartTimes, ptContract
+        trainer.getId(), existingStartTimes, ptContract
     );
 
     // 일정 등록
@@ -168,11 +170,12 @@ public class ScheduleOpenCloseService {
   }
 
   private List<ScheduleEntity> updateExistingSchedules(
+      long trainerId,
       Set<LocalDateTime> existingsStartTimes,
       PtContractEntity ptContract
   ) {
     return existingsStartTimes.stream()
-        .map(time -> scheduleRepository.findByDates(time, time).stream()
+        .map(time -> scheduleRepository.findByDates(trainerId, time, time).stream()
             .findFirst()
             .orElseThrow(ScheduleNotFoundException::new)
         )

--- a/src/test/java/com/project/trainingdiary/service/ScheduleOpenCloseServiceTest.java
+++ b/src/test/java/com/project/trainingdiary/service/ScheduleOpenCloseServiceTest.java
@@ -308,6 +308,7 @@ class ScheduleOpenCloseServiceTest {
         .build();
 
     when(scheduleRepository.findScheduleDatesByDates(
+        eq(1L),
         eq(LocalDateTime.of(2024, 1, 1, 10, 0)),
         eq(LocalDateTime.of(2024, 2, 28, 22, 0))
     ))
@@ -414,6 +415,7 @@ class ScheduleOpenCloseServiceTest {
         ));
 
     when(scheduleRepository.findScheduleDatesByDates(
+        1L,
         LocalDateTime.of(2024, 1, 2, 20, 0),
         LocalDateTime.of(2024, 1, 8, 22, 0)
     ))
@@ -461,6 +463,7 @@ class ScheduleOpenCloseServiceTest {
         ));
 
     when(scheduleRepository.findScheduleDatesByDates(
+        1L,
         LocalDateTime.of(2024, 1, 2, 20, 0),
         LocalDateTime.of(2024, 1, 8, 22, 0)
     ))
@@ -469,6 +472,7 @@ class ScheduleOpenCloseServiceTest {
         ));
 
     when(scheduleRepository.findByDates(
+        1L,
         LocalDateTime.of(2024, 1, 2, 20, 0),
         LocalDateTime.of(2024, 1, 2, 20, 0)
     ))
@@ -521,6 +525,7 @@ class ScheduleOpenCloseServiceTest {
         ));
 
     when(scheduleRepository.findScheduleDatesByDates(
+        1L,
         LocalDateTime.of(2024, 1, 2, 20, 0),
         LocalDateTime.of(2024, 1, 8, 22, 0)
     ))
@@ -529,6 +534,7 @@ class ScheduleOpenCloseServiceTest {
         ));
 
     when(scheduleRepository.findByDates(
+        1L,
         LocalDateTime.of(2024, 1, 2, 20, 0),
         LocalDateTime.of(2024, 1, 2, 20, 0)
     ))
@@ -591,6 +597,7 @@ class ScheduleOpenCloseServiceTest {
         ));
 
     when(scheduleRepository.findScheduleDatesByDates(
+        1L,
         LocalDateTime.of(2024, 1, 2, 20, 0),
         LocalDateTime.of(2024, 1, 8, 22, 0)
     ))


### PR DESCRIPTION
### 변경사항

<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요 -->
**AS-IS**
- 기존에 해당 트레이너의 일정 뿐 아니라 DB의 모든 일정을 가져오는 에러가 있음

**TO-BE**
- 일정 열기 및 일정 등록 시 기존 일정을 가져올 때, 해당 트레이너의 일정만 가져오도록 함

### 테스트

<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 

- [x] 테스트 코드
  - 기존 일정을 불러올 때, 트레이너의 아이디를 넣는 부분 추가
- [x] API 테스트
  - 일정 등록 POST api/schedules/register
    - 한 트레이너에서 일정을 등록하고, 다른 트레이너에서 같은 시간 일정을 등록해서 테스트
  - 일정 열기 POST api/schedules/open
    - 한 트레이너에서 일정을 열고, 다른 트레이너에서 같은 시간 일정을 열어서 테스트

Resolve #154 