### PR TITLE
트레이니가 기존 유효한 PT 계약이 있다면, 새로운 PT 계약을 맺으려 할 때 에러를 냄

### DIFF
--- a/src/main/java/com/project/trainingdiary/controller/PtContractController.java
+++ b/src/main/java/com/project/trainingdiary/controller/PtContractController.java
@@ -40,7 +40,8 @@ public class PtContractController {
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "성공"),
       @ApiResponse(responseCode = "406", description = "트레이니 이메일이 존재하지 않아 계약할 수 없습니다.", content = @Content),
-      @ApiResponse(responseCode = "409", description = "트레이너와 트레이니가 이미 계약이 있습니다.", content = @Content)
+      @ApiResponse(responseCode = "409", description = "트레이너와 트레이니가 이미 계약이 있습니다.", content = @Content),
+      @ApiResponse(responseCode = "410", description = "트레이니가 이미 계약이 있습니다.", content = @Content)
   })
   @PreAuthorize("hasRole('TRAINER')")
   @PostMapping

--- a/src/main/java/com/project/trainingdiary/exception/ptcontract/PtContractTraineeCanHaveOnlyOneException.java
+++ b/src/main/java/com/project/trainingdiary/exception/ptcontract/PtContractTraineeCanHaveOnlyOneException.java
@@ -1,0 +1,11 @@
+package com.project.trainingdiary.exception.ptcontract;
+
+import com.project.trainingdiary.exception.GlobalException;
+import org.springframework.http.HttpStatus;
+
+public class PtContractTraineeCanHaveOnlyOneException extends GlobalException {
+
+  public PtContractTraineeCanHaveOnlyOneException() {
+    super(HttpStatus.GONE, "트레이니가 이미 계약이 있습니다.");
+  }
+}

--- a/src/main/java/com/project/trainingdiary/repository/ptContract/PtContractRepository.java
+++ b/src/main/java/com/project/trainingdiary/repository/ptContract/PtContractRepository.java
@@ -18,6 +18,15 @@ public interface PtContractRepository extends JpaRepository<PtContractEntity, Lo
       + "and p.isTerminated = false")
   boolean existsByTrainerIdAndTraineeId(long trainerId, long traineeId);
 
+  @Query("select case when count(p) > 0 "
+      + "then true "
+      + "else false "
+      + "end "
+      + "from pt_contract p "
+      + "where p.trainee.id = ?1 "
+      + "and p.isTerminated = false")
+  boolean existsByTraineeId(long traineeId);
+
   Optional<PtContractEntity> findByIdAndIsTerminatedFalse(long ptContractId);
 
   @Query("select p "

--- a/src/main/java/com/project/trainingdiary/service/PtContractService.java
+++ b/src/main/java/com/project/trainingdiary/service/PtContractService.java
@@ -13,6 +13,7 @@ import com.project.trainingdiary.entity.TrainerEntity;
 import com.project.trainingdiary.exception.notification.UnsupportedNotificationTypeException;
 import com.project.trainingdiary.exception.ptcontract.PtContractAlreadyExistException;
 import com.project.trainingdiary.exception.ptcontract.PtContractNotExistException;
+import com.project.trainingdiary.exception.ptcontract.PtContractTraineeCanHaveOnlyOneException;
 import com.project.trainingdiary.exception.ptcontract.PtContractTrainerEmailNotExistException;
 import com.project.trainingdiary.exception.user.UserNotFoundException;
 import com.project.trainingdiary.model.NotificationMessage;
@@ -53,6 +54,13 @@ public class PtContractService {
       throw new PtContractAlreadyExistException();
     }
 
+    // 트레이니가 다른 트레이너와 PT 계약이 있다면 새로운 PT 계약을 하지 못함. 기존의 PT 계약을 종료하고 해야함.
+    // 기획상 트레이니는 한개의 유효한 PT 계약만 갖도록 함
+    if (ptContractRepository.existsByTraineeId(trainee.getId())) {
+      throw new PtContractTraineeCanHaveOnlyOneException();
+    }
+
+    // 새로운 PT 계약을 생성
     PtContractEntity ptContract = PtContractEntity.of(trainer, trainee, 0);
     ptContractRepository.save(ptContract);
 

--- a/src/test/java/com/project/trainingdiary/service/PtContractServiceTest.java
+++ b/src/test/java/com/project/trainingdiary/service/PtContractServiceTest.java
@@ -19,6 +19,7 @@ import com.project.trainingdiary.entity.TraineeEntity;
 import com.project.trainingdiary.entity.TrainerEntity;
 import com.project.trainingdiary.exception.ptcontract.PtContractAlreadyExistException;
 import com.project.trainingdiary.exception.ptcontract.PtContractNotExistException;
+import com.project.trainingdiary.exception.ptcontract.PtContractTraineeCanHaveOnlyOneException;
 import com.project.trainingdiary.exception.ptcontract.PtContractTrainerEmailNotExistException;
 import com.project.trainingdiary.model.PtContractSort;
 import com.project.trainingdiary.model.UserPrincipal;
@@ -191,7 +192,7 @@ class PtContractServiceTest {
   }
 
   @Test
-  @DisplayName("PT 계약 생성 - 실패(이미 계약이 존재하는 경우)")
+  @DisplayName("PT 계약 생성 - 실패(트레이너와 트레이니 사이에 이미 계약이 존재하는 경우)")
   void createPtContractFail_PtContractAlreadyExist() {
     //given
     setupTrainerAuth();
@@ -207,6 +208,29 @@ class PtContractServiceTest {
     //then
     assertThrows(
         PtContractAlreadyExistException.class,
+        () -> ptContractService.createPtContract(dto)
+    );
+  }
+
+  @Test
+  @DisplayName("PT 계약 생성 - 실패(트레이니가 다른 트레이너와 이미 계약이 존재하는 경우)")
+  void createPtContractFail_PtContractTraineeHaveOnlyOne() {
+    //given
+    setupTrainerAuth();
+    CreatePtContractRequestDto dto = new CreatePtContractRequestDto();
+    dto.setTraineeEmail(trainee.getEmail());
+
+    //when
+    when(traineeRepository.findByEmail(trainee.getEmail()))
+        .thenReturn(Optional.of(trainee));
+    when(ptContractRepository.existsByTrainerIdAndTraineeId(trainer.getId(), trainee.getId()))
+        .thenReturn(false);
+    when(ptContractRepository.existsByTraineeId(trainee.getId()))
+        .thenReturn(true);
+
+    //then
+    assertThrows(
+        PtContractTraineeCanHaveOnlyOneException.class,
         () -> ptContractService.createPtContract(dto)
     );
   }


### PR DESCRIPTION
### 변경사항

<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요 -->
**AS-IS**
- 트레이니가 기존 유효한 PT 계약이 있더라도, 새로운 PT 계약이 맺어지고, 일정을 신청하는 과정에서 여러 PT 계약이 있어 에러가 나게 됨

**TO-BE**
- 트레이니가 기존 유효한 PT 계약이 있다면, 새로운 PT 계약을 맺으려 할 때 에러를 내도록 함

### 테스트

<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 

- [x] 테스트 코드
  - 트레이너1 - 트레이니1 이 이미 PT 계약이 있을 때, 트레이너2가 트레이니1과 PT 계약을 맺으려 하면 에러를 내는 코드 추가
- [x] API 테스트
  - POST api/pt-contracts
  - 트레이너1 - 트레이니1 이 이미 PT 계약이 있을 때, 트레이너2 - 트레이니1 PT 계약을 맺는 api를 호출하고, 에러 응답 확인

Resolve #156 