### PR TITLE
PT 계약 종료 시 미래에 남아있던 예약 일정을 모두 제거

### DIFF
--- a/src/main/java/com/project/trainingdiary/controller/PtContractController.java
+++ b/src/main/java/com/project/trainingdiary/controller/PtContractController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -79,7 +80,7 @@ public class PtContractController {
   public ResponseEntity<Void> terminatePtContract(
       @RequestBody @Valid TerminatePtContractRequestDto dto
   ) {
-    ptContractService.terminatePtContract(dto);
+    ptContractService.terminatePtContract(dto, LocalDateTime.now());
     return ResponseEntity.ok().build();
   }
 }

--- a/src/main/java/com/project/trainingdiary/repository/schedule/ScheduleRepository.java
+++ b/src/main/java/com/project/trainingdiary/repository/schedule/ScheduleRepository.java
@@ -44,4 +44,15 @@ public interface ScheduleRepository extends JpaRepository<ScheduleEntity, Long>,
       @Param("startAt1") LocalDateTime startAt1,
       @Param("startAt2") LocalDateTime startAt2
   );
+
+  @Query("select s "
+      + "from schedule s "
+      + "where s.trainer.id = :trainerId "
+      + "and s.ptContract.trainee.id = :traineeId "
+      + "and s.startAt >= :startAt")
+  List<ScheduleEntity> findByTraineeIdAndDateAfter(
+      @Param("trainerId") long trainerId,
+      @Param("traineeId") long traineeId,
+      @Param("startAt") LocalDateTime startAt
+  );
 }

--- a/src/main/java/com/project/trainingdiary/repository/schedule/ScheduleRepositoryCustom.java
+++ b/src/main/java/com/project/trainingdiary/repository/schedule/ScheduleRepositoryCustom.java
@@ -13,7 +13,7 @@ public interface ScheduleRepositoryCustom {
   );
 
   List<ScheduleResponseDto> getScheduleListByTrainee(
-      long trainerId,
+      Long trainerId,
       long traineeId,
       LocalDateTime startDateTime,
       LocalDateTime endDateTime

--- a/src/main/java/com/project/trainingdiary/service/PtContractService.java
+++ b/src/main/java/com/project/trainingdiary/service/PtContractService.java
@@ -8,6 +8,7 @@ import com.project.trainingdiary.dto.response.ptcontract.CreatePtContractRespons
 import com.project.trainingdiary.dto.response.ptcontract.PtContractResponseDto;
 import com.project.trainingdiary.entity.NotificationEntity;
 import com.project.trainingdiary.entity.PtContractEntity;
+import com.project.trainingdiary.entity.ScheduleEntity;
 import com.project.trainingdiary.entity.TraineeEntity;
 import com.project.trainingdiary.entity.TrainerEntity;
 import com.project.trainingdiary.exception.notification.UnsupportedNotificationTypeException;
@@ -23,13 +24,16 @@ import com.project.trainingdiary.repository.NotificationRepository;
 import com.project.trainingdiary.repository.TraineeRepository;
 import com.project.trainingdiary.repository.TrainerRepository;
 import com.project.trainingdiary.repository.ptContract.PtContractRepository;
+import com.project.trainingdiary.repository.schedule.ScheduleRepository;
 import com.project.trainingdiary.util.NotificationMessageGeneratorUtil;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @AllArgsConstructor
@@ -40,6 +44,7 @@ public class PtContractService {
   private final TraineeRepository traineeRepository;
   private final NotificationRepository notificationRepository;
   private final FcmPushNotification fcmPushNotification;
+  private final ScheduleRepository scheduleRepository;
 
   /**
    * PT 계약 생성
@@ -97,11 +102,21 @@ public class PtContractService {
   /**
    * PT 계약을 종료함
    */
-  public void terminatePtContract(TerminatePtContractRequestDto dto) {
+  @Transactional
+  public void terminatePtContract(TerminatePtContractRequestDto dto, LocalDateTime now) {
     PtContractEntity ptContract = ptContractRepository.findByIdAndIsTerminatedFalse(
             dto.getPtContractId())
         .orElseThrow(PtContractNotExistException::new);
 
+    // 남아있던 미래의 일정을 모두 취소(OPEN으로 변경)
+    scheduleRepository.findByTraineeIdAndDateAfter(
+            ptContract.getTrainer().getId(),
+            ptContract.getTrainee().getId(),
+            now
+        )
+        .forEach(ScheduleEntity::cancel);
+
+    // PT 계약을 종료
     ptContract.terminate();
     ptContractRepository.save(ptContract);
   }

--- a/src/main/java/com/project/trainingdiary/service/ScheduleTraineeService.java
+++ b/src/main/java/com/project/trainingdiary/service/ScheduleTraineeService.java
@@ -150,11 +150,14 @@ public class ScheduleTraineeService {
   }
 
   /**
-   * 트레이너의 일정 목록 조회
+   * 트레이니의 일정 목록 조회
    */
   public List<ScheduleResponseDto> getScheduleList(LocalDate startDate, LocalDate endDate) {
     TraineeEntity trainee = getTrainee();
-    PtContractEntity ptContract = getPtContract(trainee.getId());
+    Long currentTrainerId = ptContractRepository.findByTraineeId(trainee.getId())
+        .map(PtContractEntity::getTrainer)
+        .map(TrainerEntity::getId)
+        .orElse(null);
 
     LocalDateTime startDateTime = LocalDateTime.of(startDate, START_TIME);
     LocalDateTime endDateTime = LocalDateTime.of(endDate, END_TIME);
@@ -164,7 +167,7 @@ public class ScheduleTraineeService {
     }
 
     return scheduleRepository.getScheduleListByTrainee(
-        ptContract.getTrainer().getId(),
+        currentTrainerId,
         trainee.getId(),
         startDateTime,
         endDateTime

--- a/src/test/java/com/project/trainingdiary/service/PtContractServiceTest.java
+++ b/src/test/java/com/project/trainingdiary/service/PtContractServiceTest.java
@@ -15,6 +15,7 @@ import com.project.trainingdiary.dto.request.ptcontract.CreatePtContractRequestD
 import com.project.trainingdiary.dto.request.ptcontract.TerminatePtContractRequestDto;
 import com.project.trainingdiary.entity.NotificationEntity;
 import com.project.trainingdiary.entity.PtContractEntity;
+import com.project.trainingdiary.entity.ScheduleEntity;
 import com.project.trainingdiary.entity.TraineeEntity;
 import com.project.trainingdiary.entity.TrainerEntity;
 import com.project.trainingdiary.exception.ptcontract.PtContractAlreadyExistException;
@@ -23,11 +24,13 @@ import com.project.trainingdiary.exception.ptcontract.PtContractTrainerEmailNotE
 import com.project.trainingdiary.model.PtContractSort;
 import com.project.trainingdiary.model.UserPrincipal;
 import com.project.trainingdiary.model.type.NotificationType;
+import com.project.trainingdiary.model.type.ScheduleStatusType;
 import com.project.trainingdiary.model.type.UserRoleType;
 import com.project.trainingdiary.repository.NotificationRepository;
 import com.project.trainingdiary.repository.TraineeRepository;
 import com.project.trainingdiary.repository.TrainerRepository;
 import com.project.trainingdiary.repository.ptContract.PtContractRepository;
+import com.project.trainingdiary.repository.schedule.ScheduleRepository;
 import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Collections;
@@ -64,6 +67,9 @@ class PtContractServiceTest {
 
   @Mock
   private TraineeRepository traineeRepository;
+
+  @Mock
+  private ScheduleRepository scheduleRepository;
 
   @Mock
   private NotificationRepository notificationRepository;
@@ -317,6 +323,7 @@ class PtContractServiceTest {
     setupTrainerAuth();
     TerminatePtContractRequestDto dto = new TerminatePtContractRequestDto();
     dto.setPtContractId(100L);
+    LocalDateTime now = LocalDateTime.of(2024, 7, 1, 0, 0, 0);
 
     //when
     when(ptContractRepository.findByIdAndIsTerminatedFalse(100L))
@@ -329,9 +336,18 @@ class PtContractServiceTest {
                 .totalSessionUpdatedAt(LocalDateTime.now())
                 .build()
         ));
+    when(scheduleRepository.findByTraineeIdAndDateAfter(1L, 10L, now))
+        .thenReturn(List.of(
+            ScheduleEntity.builder()
+                .id(1L)
+                .scheduleStatusType(ScheduleStatusType.RESERVED)
+                .startAt(LocalDateTime.of(2024, 7, 2, 16, 0, 0))
+                .trainer(trainer)
+                .build()
+        ));
 
     //then
-    ptContractService.terminatePtContract(dto);
+    ptContractService.terminatePtContract(dto, now);
   }
 
   @Test
@@ -341,6 +357,7 @@ class PtContractServiceTest {
     setupTrainerAuth();
     TerminatePtContractRequestDto dto = new TerminatePtContractRequestDto();
     dto.setPtContractId(100L);
+    LocalDateTime now = LocalDateTime.now();
 
     //when
     when(ptContractRepository.findByIdAndIsTerminatedFalse(100L))
@@ -349,7 +366,7 @@ class PtContractServiceTest {
     //then
     assertThrows(
         PtContractNotExistException.class,
-        () -> ptContractService.terminatePtContract(dto)
+        () -> ptContractService.terminatePtContract(dto, now)
     );
   }
 }


### PR DESCRIPTION
### 변경사항

<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요 -->
**AS-IS**
- PT 계약 종료 시에도 미래의 예약 일정이 남아있음
- PT 계약이 종료된 트레이니가 일정을 조회하면 계약이 없다는 404 에러가 나감

**TO-BE**
- PT 계약 종료 시 미래에 남아있던 예약 일정을 모두 OPEN 상태로 바꾸고, 연결된 PT 계약을 제거함
- PT 계약이 종료된 경우라도 트레이니가 일정을 조회할 수 있도록 수정(트레이니 자신의 일정만 보여줌)

### 테스트

<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 

- [x] API 테스트
  - 위 내용을 테스트하려면 아래 순서로 실행
    1. PT 계약 생성 -> 트레이니 정보에서 잔여횟수 증가 -> 일정 등록
    2. 트레이너의 일정 조회 -> 등록된 일정 확인
    3. 트레이니의 일정 조회 -> 등록된 일정 확인
    4. PT 계약 취소
    5. 트레이너의 일정 조회 -> 등록되었던 일정이 OPEN인지 확인
    6. 트레이니의 일정 조회 -> 일정이 없어진 것 확인 (과거에 PT를 했던 일정은 표시됨)