### PR TITLE
트레이너의 트레이니 조회 API 트레이니 본인도 조회할 수 있도록 구현

### DIFF
--- a/src/main/java/com/project/trainingdiary/controller/TrainerController.java
+++ b/src/main/java/com/project/trainingdiary/controller/TrainerController.java
@@ -37,7 +37,8 @@ public class TrainerController {
   )
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "성공"),
-      @ApiResponse(responseCode = "400", description = "다른 트레이니의 정보를 볼 없습니다.", content = @Content)
+      @ApiResponse(responseCode = "400", description = "다른 트레이니의 정보를 볼 없습니다.", content = @Content),
+      @ApiResponse(responseCode = "404", description = "계약이 없습니다.", content = @Content)
   })
   @PreAuthorize("hasRole('TRAINER') or hasRole('TRAINEE')")
   @GetMapping("/trainees/{id}")

--- a/src/main/java/com/project/trainingdiary/controller/TrainerController.java
+++ b/src/main/java/com/project/trainingdiary/controller/TrainerController.java
@@ -7,6 +7,7 @@ import com.project.trainingdiary.dto.response.trainer.EditTraineeInfoResponseDto
 import com.project.trainingdiary.dto.response.trainer.TraineeInfoResponseDto;
 import com.project.trainingdiary.service.TrainerService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -32,12 +33,13 @@ public class TrainerController {
 
   @Operation(
       summary = "트레이니 정보 조회",
-      description = "트레이너가 트레이니 정보를 조회합니다."
+      description = "트레이너 및 트레이니가 트레이니 정보를 조회합니다."
   )
   @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", description = "성공")
+      @ApiResponse(responseCode = "200", description = "성공"),
+      @ApiResponse(responseCode = "400", description = "다른 트레이니의 정보를 볼 없습니다.", content = @Content)
   })
-  @PreAuthorize("hasRole('TRAINER')")
+  @PreAuthorize("hasRole('TRAINER') or hasRole('TRAINEE')")
   @GetMapping("/trainees/{id}")
   public ResponseEntity<TraineeInfoResponseDto> getTraineeInfo(
       @PathVariable Long id

--- a/src/main/java/com/project/trainingdiary/exception/user/UnauthorizedTraineeException.java
+++ b/src/main/java/com/project/trainingdiary/exception/user/UnauthorizedTraineeException.java
@@ -1,0 +1,11 @@
+package com.project.trainingdiary.exception.user;
+
+import com.project.trainingdiary.exception.GlobalException;
+import org.springframework.http.HttpStatus;
+
+public class UnauthorizedTraineeException extends GlobalException {
+
+  public UnauthorizedTraineeException() {
+    super(HttpStatus.BAD_REQUEST, "다른 트레이니 정보를 볼 수 없습니다.");
+  }
+}

--- a/src/main/java/com/project/trainingdiary/repository/ptContract/PtContractRepository.java
+++ b/src/main/java/com/project/trainingdiary/repository/ptContract/PtContractRepository.java
@@ -2,8 +2,10 @@ package com.project.trainingdiary.repository.ptContract;
 
 import com.project.trainingdiary.entity.PtContractEntity;
 import java.util.Optional;
+import org.springframework.boot.context.properties.bind.BindResult;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PtContractRepository extends JpaRepository<PtContractEntity, Long>,
     PtContractRepositoryCustom {
@@ -41,4 +43,11 @@ public interface PtContractRepository extends JpaRepository<PtContractEntity, Lo
       + "where p.trainee.id = ?1 "
       + "and p.isTerminated = false")
   Optional<PtContractEntity> findByTraineeId(long traineeId);
+
+  @Query("SELECT ptc FROM pt_contract ptc " +
+      "LEFT JOIN FETCH ptc.trainee t " +
+      "LEFT JOIN FETCH t.inBodyRecords ir " +
+      "LEFT JOIN FETCH ptc.trainer tr " +
+      "WHERE t.id = :traineeId AND tr.id = :trainerId AND ptc.isTerminated = false")
+  Optional<PtContractEntity> findWithTraineeAndTrainer(@Param("traineeId") Long traineeId, @Param("trainerId") Long trainerId);
 }

--- a/src/main/java/com/project/trainingdiary/repository/ptContract/PtContractRepository.java
+++ b/src/main/java/com/project/trainingdiary/repository/ptContract/PtContractRepository.java
@@ -2,7 +2,6 @@ package com.project.trainingdiary.repository.ptContract;
 
 import com.project.trainingdiary.entity.PtContractEntity;
 import java.util.Optional;
-import org.springframework.boot.context.properties.bind.BindResult;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -49,5 +48,12 @@ public interface PtContractRepository extends JpaRepository<PtContractEntity, Lo
       "LEFT JOIN FETCH t.inBodyRecords ir " +
       "LEFT JOIN FETCH ptc.trainer tr " +
       "WHERE t.id = :traineeId AND tr.id = :trainerId AND ptc.isTerminated = false")
-  Optional<PtContractEntity> findWithTraineeAndTrainer(@Param("traineeId") Long traineeId, @Param("trainerId") Long trainerId);
+  Optional<PtContractEntity> findWithTraineeAndTrainer(@Param("traineeId") Long traineeId,
+      @Param("trainerId") Long trainerId);
+
+  @Query("SELECT ptc FROM pt_contract ptc " +
+      "LEFT JOIN FETCH ptc.trainee t " +
+      "LEFT JOIN FETCH t.inBodyRecords ir " +
+      "WHERE t.id = :traineeId AND ptc.isTerminated = false")
+  Optional<PtContractEntity> findByTraineeIdWithInBodyRecords(@Param("traineeId") Long traineeId);
 }


### PR DESCRIPTION
### 변경사항

- **트레이너 및 트레이니 정보 조회 기능 추가 및 최적화**:
  - 트레이니가 자신의 정보를 조회할 수 있는 기능 추가. 다른 트레이니의 정보를 조회하려고 할 경우 예외 처리.
  - 서비스 메서드 리팩토링 및 주석 추가.
  - JPQL을 사용하여 쿼리를 최적화, 5개의 쿼리를 1개의 쿼리로 줄임 (fetch join left 등 사용).
  - 인증된 사용자 정보를 캐싱하여 데이터베이스 쿼리 감소.
  - 관련 유닛 테스트 및 통합 테스트 작성.

### 관련 이슈 및 반영 브랜치

- **Issue**: #161 
- **Branch**: 
  - FROM: `feature/trainee-view-trainee-info`
  - TO: `main`

---

## 설명

이번 변경사항은 트레이니가 자신의 정보를 조회할 수 있는 기능을 추가한 것입니다. 트레이니가 다른 트레이니의 정보를 조회하려고 할 경우 예외를 처리하도록 구현하였습니다. 또한, 관련된 서비스 메서드를 리팩토링하고, JPQL을 사용하여 쿼리를 최적화하였습니다. 인증된 사용자 정보를 캐싱하여 데이터베이스 쿼리를 줄였습니다. 각 기능에 대한 유닛 테스트 및 통합 테스트를 작성하였습니다.

### ASIS

- 기존에는 트레이니가 자신의 정보를 조회할 수 없었습니다.
- 데이터베이스 쿼리가 최적화되지 않아 여러 번의 쿼리가 발생했습니다.

### TOBE

- 트레이니는 자신의 정보를 조회할 수 있습니다. 다른 트레이니의 정보를 조회하려고 할 경우 예외가 발생합니다.
- 서비스 메서드를 리팩토링하여 가독성이 향상되었고, 각 메서드에 주석을 추가하였습니다.
- JPQL을 사용하여 쿼리를 최적화하고, 5개의 쿼리를 1개의 쿼리로 줄였습니다 (fetch join left 등 사용).
- 인증된 사용자 정보를 캐싱하여 데이터베이스 쿼리 발생 빈도를 줄였습니다.
- 각 기능에 대한 유닛 테스트 및 통합 테스트가 작성되었습니다.

### 테스트 케이스

- 캐시된 사용자가 정보를 조회할 수 있는지 확인.
- API 응답이 올바른지 확인.
- 트레이니가 다른 트레이니의 정보를 조회하려고 할 때 실패하는지 확인.
- 트레이니가 자신의 정보를 조회할 수 있는지 확인.
- 경계 조건 테스트를 포함한 다양한 시나리오에 대한 테스트.

### 참고 사항

- 새로운 기능이 기존 시스템과 호환되는지 확인해야 합니다.
- 리팩토링 및 최적화 후 기존 기능이 정상적으로 동작하는지 확인해야 합니다.

---

### 결론

이번 변경사항을 통해 트레이너가 트레이니의 정보를 조회할 수 있는 기능과 트레이니가 자신의 정보를 조회할 수 있는 기능을 추가하였습니다. 또한, JPQL을 사용하여 쿼리를 최적화하고, 인증된 사용자 정보를 캐싱하여 시스템 성능을 향상시켰습니다. 이를 통해 시스템의 유지보수성과 확장성을 높일 수 있을 것으로 기대됩니다. 관련된 유닛 테스트와 통합 테스트를 작성하여 각 기능의 정확성을 검증하였습니다.