### PR TITLE
fix: 트레이니 계약 없이 호출 가능하도록 수정

### DIFF
--- a/src/main/java/com/project/trainingdiary/repository/TraineeRepository.java
+++ b/src/main/java/com/project/trainingdiary/repository/TraineeRepository.java
@@ -1,10 +1,15 @@
 package com.project.trainingdiary.repository;
 
 import com.project.trainingdiary.entity.TraineeEntity;
+import io.lettuce.core.dynamic.annotation.Param;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface TraineeRepository extends JpaRepository<TraineeEntity, Long> {
 
   Optional<TraineeEntity> findByEmail(String email);
+
+  @Query("SELECT t FROM trainee t LEFT JOIN FETCH t.inBodyRecords WHERE t.id = :id")
+  Optional<TraineeEntity> findByIdWithInBodyRecords(@Param("id") Long id);
 }


### PR DESCRIPTION
### 변경사항

- **버그 수정**:
  - 계약이 없는 트레이니가 대시보드에서 자신의 정보를 조회할 수 없는 문제 수정.

### 관련 이슈 및 반영 브랜치

- **Issue**: #163 
- **Branch**: 
  - FROM: `fix/trainee-view-info`
  - TO: `main`

---

## 설명

이번 변경사항은 계약이 없는 트레이니가 대시보드에서 자신의 정보를 조회할 수 없는 문제를 수정한 것입니다. 트레이니가 계약 상태와 상관없이 대시보드에서 자신의 정보를 조회할 수 있도록 기능을 개선하였습니다.

### ASIS

- 기존에는 계약이 없는 트레이니가 대시보드에서 자신의 정보를 조회할 수 없었습니다.

### TOBE

- 트레이니는 계약 상태와 상관없이 대시보드에서 자신의 정보를 조회할 수 있습니다.

### 참고 사항

- 새로운 기능이 기존 시스템과 호환되는지 확인해야 합니다.
- 기능 수정 후 기존 기능이 정상적으로 동작하는지 확인해야 합니다.

---

### 결론

이번 변경사항을 통해 계약이 없는 트레이니가 대시보드에서 자신의 정보를 조회할 수 없는 문제를 수정하였습니다. 이를 통해 트레이니의 사용자 경험을 개선하고 시스템의 유지보수성을 높일 수 있을 것으로 기대됩니다.