### PR TITLE
다이어트 API 및 댓글 API 개선

### DIFF
--- a/src/main/java/com/project/trainingdiary/controller/CommentController.java
+++ b/src/main/java/com/project/trainingdiary/controller/CommentController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "8 - Comment API", description = "트레이너의 식단 댓글 관리 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("api/comments/")
+@RequestMapping("api/comments")
 public class CommentController {
 
   private final CommentService commentService;
@@ -67,7 +67,7 @@ public class CommentController {
       @ApiResponse(responseCode = "200", description = "성공"),
   })
   @PreAuthorize("hasRole('TRAINER')")
-  @DeleteMapping("{id}")
+  @DeleteMapping("/{id}")
   public ResponseEntity<Void> deleteTrainerComment(
       @PathVariable Long id
   ) {

--- a/src/main/java/com/project/trainingdiary/controller/DietController.java
+++ b/src/main/java/com/project/trainingdiary/controller/DietController.java
@@ -48,7 +48,7 @@ public class DietController {
   @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   public ResponseEntity<Void> createDiet(
       @RequestPart("image") MultipartFile image,
-      @RequestParam("content") String content
+      @RequestPart("content") String content
   ) throws IOException {
     CreateDietRequestDto dto = CreateDietRequestDto.builder()
         .image(image)

--- a/src/main/java/com/project/trainingdiary/controller/DietController.java
+++ b/src/main/java/com/project/trainingdiary/controller/DietController.java
@@ -30,7 +30,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "7 - Diet API", description = "트레이니의 식단 관련 API")
 @RestController
-@RequestMapping("api/diets/")
+@RequestMapping("api/diets")
 @RequiredArgsConstructor
 public class DietController {
 
@@ -48,7 +48,7 @@ public class DietController {
   @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   public ResponseEntity<Void> createDiet(
       @RequestPart("image") MultipartFile image,
-      @RequestPart("content") String content
+      @RequestParam("content") String content
   ) throws IOException {
     CreateDietRequestDto dto = CreateDietRequestDto.builder()
         .image(image)
@@ -63,10 +63,9 @@ public class DietController {
       summary = "식단 목록 조회",
       description = "트레이니의 식단 목록을 페이징하여 조회합니다."
   )
-  @GetMapping("{id}")
+  @GetMapping("/{id}")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "성공"),
-      @ApiResponse(responseCode = "403", description = "트레이너랑 트레이니 사이의 계약이 없습니다.")
   })
   @PreAuthorize("hasRole('TRAINER') or hasRole('TRAINEE')")
   public ResponseEntity<Page<DietImageResponseDto>> getTraineeDiets(
@@ -86,10 +85,9 @@ public class DietController {
   )
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200", description = "성공"),
-      @ApiResponse(responseCode = "403", description = "트레이너랑 트레이니 사이의 계약이 없습니다.")
   })
   @PreAuthorize("hasRole('TRAINER') or hasRole('TRAINEE')")
-  @GetMapping("{id}/details")
+  @GetMapping("/{id}/details")
   public ResponseEntity<DietDetailsInfoResponseDto> getDietDetails(
       @PathVariable Long id
   ) {
@@ -104,7 +102,7 @@ public class DietController {
       @ApiResponse(responseCode = "200", description = "성공"),
   })
   @PreAuthorize("hasRole('TRAINEE')")
-  @DeleteMapping("{id}")
+  @DeleteMapping("/{id}")
   public ResponseEntity<Void> deleteDiet(@PathVariable Long id) {
     dietService.deleteDiet(id);
     return ResponseEntity.ok().build();

--- a/src/main/java/com/project/trainingdiary/dto/response/diet/DietDetailsInfoResponseDto.java
+++ b/src/main/java/com/project/trainingdiary/dto/response/diet/DietDetailsInfoResponseDto.java
@@ -22,7 +22,6 @@ public class DietDetailsInfoResponseDto {
   public static DietDetailsInfoResponseDto of(DietEntity diet, List<CommentEntity> comments) {
 
     List<CommentDto> commentDtoList = comments.stream()
-        .sorted((a, b) -> b.getCreatedAt().compareTo(a.getCreatedAt())) // 최신 댓글이 위로 오도록 정렬
         .map(CommentDto::fromEntity) // CommentEntity를 CommentDto로 변환
         .toList();
 

--- a/src/main/java/com/project/trainingdiary/exception/ptcontract/PtContractNotExistException.java
+++ b/src/main/java/com/project/trainingdiary/exception/ptcontract/PtContractNotExistException.java
@@ -6,6 +6,6 @@ import org.springframework.http.HttpStatus;
 public class PtContractNotExistException extends GlobalException {
 
   public PtContractNotExistException() {
-    super(HttpStatus.FORBIDDEN, "계약이 없습니다.");
+    super(HttpStatus.NOT_FOUND, "계약이 없습니다.");
   }
 }

--- a/src/main/java/com/project/trainingdiary/repository/DietRepository.java
+++ b/src/main/java/com/project/trainingdiary/repository/DietRepository.java
@@ -10,8 +10,6 @@ import org.springframework.data.repository.query.Param;
 
 public interface DietRepository extends JpaRepository<DietEntity, Long> {
 
-  Page<DietEntity> findByTraineeId(Long traineeId, Pageable pageable);
-
   Optional<DietEntity> findByTraineeIdAndId(Long id, Long id1);
 
   @Query("SELECT d FROM diet d " +
@@ -26,4 +24,7 @@ public interface DietRepository extends JpaRepository<DietEntity, Long> {
       "WHERE d.id = :id AND d.trainee.id = :traineeId")
   Optional<DietEntity> findByTraineeIdAndIdWithCommentsAndTrainer(
       @Param("traineeId") Long traineeId, @Param("id") Long id);
+
+  @Query("SELECT d FROM diet d WHERE d.trainee.id = :traineeId ORDER BY d.createdAt DESC")
+  Page<DietEntity> findDietImagesByTraineeId(@Param("traineeId") Long traineeId, Pageable pageable);
 }

--- a/src/main/java/com/project/trainingdiary/service/DietService.java
+++ b/src/main/java/com/project/trainingdiary/service/DietService.java
@@ -1,5 +1,6 @@
 package com.project.trainingdiary.service;
 
+import com.github.benmanes.caffeine.cache.Cache;
 import com.project.trainingdiary.dto.request.diet.CreateDietRequestDto;
 import com.project.trainingdiary.dto.response.diet.DietDetailsInfoResponseDto;
 import com.project.trainingdiary.dto.response.diet.DietImageResponseDto;
@@ -10,8 +11,8 @@ import com.project.trainingdiary.exception.diet.DietNotExistException;
 import com.project.trainingdiary.exception.ptcontract.PtContractNotExistException;
 import com.project.trainingdiary.exception.user.TraineeNotFoundException;
 import com.project.trainingdiary.exception.user.TrainerNotFoundException;
-import com.project.trainingdiary.exception.user.UserNotFoundException;
 import com.project.trainingdiary.exception.workout.InvalidFileTypeException;
+import com.project.trainingdiary.model.UserPrincipal;
 import com.project.trainingdiary.model.type.UserRoleType;
 import com.project.trainingdiary.provider.S3DietImageProvider;
 import com.project.trainingdiary.repository.DietRepository;
@@ -43,6 +44,8 @@ public class DietService {
 
   private final S3DietImageProvider s3DietImageProvider;
 
+  private final Cache<String, UserPrincipal> userCache;
+
   /**
    * 새로운 식단을 생성합니다.
    *
@@ -54,7 +57,6 @@ public class DietService {
   public void createDiet(CreateDietRequestDto dto) throws IOException {
     TraineeEntity trainee = getAuthenticatedTrainee();
     MultipartFile imageFile = dto.getImage();
-
     validateImageFileType(imageFile);
 
     String originalUrl = s3DietImageProvider.uploadImageToS3(imageFile);
@@ -77,8 +79,6 @@ public class DietService {
    * @param id       조회할 트레이니의 ID
    * @param pageable 페이지 요청 정보
    * @return 트레이니의 식단 페이지
-   * @throws PtContractNotExistException 트레이너와 트레이니 사이에 계약이 없을 경우 예외 발생
-   * @throws UserNotFoundException       인증된 사용자가 트레이니 또는 트레이너가 아닐 경우 예외 발생
    */
   public Page<DietImageResponseDto> getDiets(Long id, Pageable pageable) {
     UserRoleType role = getMyRole();
@@ -102,7 +102,8 @@ public class DietService {
     TraineeEntity trainee = getTraineeById(id);
     validateContractWithTrainee(trainer, trainee);
 
-    return mapToDietImageResponseDtos(dietRepository.findByTraineeId(id, pageable));
+    Page<DietEntity> page = dietRepository.findDietImagesByTraineeId(id, pageable);
+    return mapToDietImageResponseDtos(page);
   }
 
   /**
@@ -119,7 +120,8 @@ public class DietService {
       throw new DietNotExistException();
     }
 
-    return mapToDietImageResponseDtos(dietRepository.findByTraineeId(id, pageable));
+    Page<DietEntity> page = dietRepository.findDietImagesByTraineeId(id, pageable);
+    return mapToDietImageResponseDtos(page);
   }
 
   /**
@@ -127,7 +129,6 @@ public class DietService {
    *
    * @param id 식단 ID
    * @return 식단 상세 정보 DTO
-   * @throws DietNotExistException 식단이 존재하지 않을 경우 예외 발생
    */
   public DietDetailsInfoResponseDto getDietDetails(Long id) {
     UserRoleType role = getMyRole();
@@ -177,7 +178,7 @@ public class DietService {
    * 트레이니의 식단을 삭제합니다.
    *
    * @param id 식단 ID
-   * @throws DietNotExistException 식단이 존재하지 않을 위해 예외 발생
+   * @throws DietNotExistException 식단이 존재하지 않을 경우 예외 발생
    */
   @Transactional
   public void deleteDiet(Long id) {
@@ -210,9 +211,18 @@ public class DietService {
    * @throws TraineeNotFoundException 인증된 트레이니가 존재하지 않을 경우 예외 발생
    */
   private TraineeEntity getAuthenticatedTrainee() {
-    Authentication authentication = getAuthentication();
-    String email = authentication.getName();
-    return traineeRepository.findByEmail(email)
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication == null
+        || !(authentication.getPrincipal() instanceof UserPrincipal userPrincipal)) {
+      throw new TraineeNotFoundException();
+    }
+
+    UserPrincipal cachedUser = userCache.getIfPresent(userPrincipal.getEmail());
+    if (cachedUser != null && cachedUser.getTrainee() != null) {
+      return cachedUser.getTrainee();
+    }
+
+    return traineeRepository.findByEmail(userPrincipal.getEmail())
         .orElseThrow(TraineeNotFoundException::new);
   }
 
@@ -223,12 +233,20 @@ public class DietService {
    * @throws TrainerNotFoundException 인증된 트레이너가 존재하지 않을 경우 예외 발생
    */
   private TrainerEntity getAuthenticatedTrainer() {
-    Authentication authentication = getAuthentication();
-    String email = authentication.getName();
-    return trainerRepository.findByEmail(email)
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication == null
+        || !(authentication.getPrincipal() instanceof UserPrincipal userPrincipal)) {
+      throw new TrainerNotFoundException();
+    }
+
+    UserPrincipal cachedUser = userCache.getIfPresent(userPrincipal.getEmail());
+    if (cachedUser != null && cachedUser.getTrainer() != null) {
+      return cachedUser.getTrainer();
+    }
+
+    return trainerRepository.findByEmail(userPrincipal.getEmail())
         .orElseThrow(TrainerNotFoundException::new);
   }
-
 
   /**
    * 트레이니 ID로 트레이니를 조회합니다.
@@ -276,26 +294,6 @@ public class DietService {
     s3DietImageProvider.deleteFileFromS3(diet.getThumbnailUrl());
   }
 
-  /**
-   * Authentication 객체를 반환합니다.
-   *
-   * @return 인증된 Authentication 객체
-   * @throws TraineeNotFoundException 인증된 트레이니가 존재하지 않을 경우 예외 발생
-   */
-  private Authentication getAuthentication() {
-    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-    if (authentication == null || authentication.getName() == null) {
-      throw new TraineeNotFoundException();
-    }
-    return authentication;
-  }
-
-  /**
-   * 다이어트 엔티티 페이지를 다이어트 이미지 응답 DTO 페이지로 변환합니다.
-   *
-   * @param dietPage 다이어트 엔티티 페이지
-   * @return 다이어트 이미지 응답 DTO 페이지
-   */
   private Page<DietImageResponseDto> mapToDietImageResponseDtos(Page<DietEntity> dietPage) {
     return dietPage.map(diet -> DietImageResponseDto.builder()
         .dietId(diet.getId())

--- a/src/main/java/com/project/trainingdiary/service/DietService.java
+++ b/src/main/java/com/project/trainingdiary/service/DietService.java
@@ -294,6 +294,12 @@ public class DietService {
     s3DietImageProvider.deleteFileFromS3(diet.getThumbnailUrl());
   }
 
+  /**
+   * 다이어트 엔티티 페이지를 다이어트 이미지 응답 DTO 페이지로 변환합니다.
+   *
+   * @param dietPage 다이어트 엔티티 페이지
+   * @return 다이어트 이미지 응답 DTO 페이지
+   */
   private Page<DietImageResponseDto> mapToDietImageResponseDtos(Page<DietEntity> dietPage) {
     return dietPage.map(diet -> DietImageResponseDto.builder()
         .dietId(diet.getId())


### PR DESCRIPTION
### 변경사항

- **다이어트 API 및 댓글 API 개선**:
  - 다이어트 API 및 댓글 API의 요청 매핑에 백슬래시 `/` 추가.
  - 계약이 없는 경우의 오류 코드를 403에서 404로 변경.
  - 트레이너와 트레이니가 다이어트 세부 정보 및 다이어트 목록을 조회할 때 쿼리 최적화.
  - 트레이너 및 트레이니 조회 시 캐싱 도입.

### 관련 이슈 및 반영 브랜치

- **Issue**: #171 
- **Branch**: 
  - FROM: `enhancement/diet-api`
  - TO: `main`

---

## 설명

이번 변경사항은 다이어트 API 및 댓글 API의 요청 매핑에 백슬래시를 추가하고, 계약이 없는 경우의 오류 코드를 403에서 404로 변경하는 것입니다. 또한, 트레이너와 트레이니가 다이어트 세부 정보 및 다이어트 목록을 조회할 때 쿼리를 최적화하여 성능을 향상시키고, 트레이너 및 트레이니 조회 시 캐싱을 도입하여 데이터베이스 부하를 줄였습니다.

### ASIS

- 기존에는 다이어트 API 및 댓글 API의 요청 매핑에 백슬래시가 없었습니다.
- 계약이 없는 경우의 오류 코드가 403으로 설정되어 있었습니다.
- 다이어트 세부 정보 및 다이어트 목록 조회 시 쿼리가 최적화되지 않았습니다.

### TOBE

- 다이어트 API 및 댓글 API의 요청 매핑에 백슬래시가 추가되었습니다.
- 계약이 없는 경우의 오류 코드가 404로 변경되었습니다.
- 트레이너와 트레이니가 다이어트 세부 정보 및 다이어트 목록을 조회할 때 쿼리가 최적화되었습니다.
- 트레이너 및 트레이니 조회 시 캐싱이 도입되어 데이터베이스 부하가 감소하였습니다.

### 참고 사항

- 새로운 기능이 기존 시스템과 호환되는지 확인해야 합니다.
- 쿼리 최적화 및 캐싱 도입 후 기능이 정상적으로 동작하는지 확인해야 합니다.

---

### 결론

이번 변경사항을 통해 다이어트 API 및 댓글 API의 요청 매핑에 백슬래시를 추가하고, 계약이 없는 경우의 오류 코드를 403에서 404로 변경하였습니다. 또한, 쿼리를 최적화하고 캐싱을 도입하여 트레이너와 트레이니가 다이어트 세부 정보 및 다이어트 목록을 더욱 효율적으로 조회할 수 있도록 개선하였습니다. 이를 통해 시스템의 성능과 사용자 경험이 향상될 것으로 기대됩니다.